### PR TITLE
feat(eval): use proper exceptions instead of deprecated Error object

### DIFF
--- a/object/exception.go
+++ b/object/exception.go
@@ -37,6 +37,12 @@ func formatException(exception RubyObject, message string) string {
 	return fmt.Sprintf("%s: %s", reflect.TypeOf(exception).Elem().Name(), message)
 }
 
+// NewException creates a new exception with the given message template and
+//uses fmt.Sprintf to interpolate the args into messageinto message.
+func NewException(message string, args ...interface{}) *Exception {
+	return &Exception{Message: fmt.Sprintf(message, args...)}
+}
+
 // Exception represents a basic exception
 type Exception struct {
 	Message string
@@ -119,6 +125,18 @@ func (e *ArgumentError) Inspect() string { return formatException(e, e.Message) 
 
 // Class returns argumentErrorClass
 func (e *ArgumentError) Class() RubyClass { return argumentErrorClass }
+
+// NewNameError returns a NameError with the default message for undefined names
+func NewNameError(context RubyObject, method string) *NameError {
+	return &NameError{
+		Message: fmt.Sprintf(
+			"undefined local variable or method `%s' for %s:%s",
+			method,
+			context.Inspect(),
+			context.Class().(RubyObject).Inspect(),
+		),
+	}
+}
 
 // A NameError represents an error accessing an identifier unknown to the environment
 type NameError struct {

--- a/object/ruby_object.go
+++ b/object/ruby_object.go
@@ -31,7 +31,6 @@ const (
 	BOOLEAN_CLASS_OBJ      Type = "BOOLEAN_CLASS"
 	NIL_OBJ                Type = "NIL"
 	NIL_CLASS_OBJ          Type = "NIL_CLASS"
-	ERROR_OBJ              Type = "ERROR"
 	EXCEPTION_OBJ          Type = "EXCEPTION"
 	EXCEPTION_CLASS_OBJ    Type = "EXCEPTION_CLASS"
 	MODULE_OBJ             Type = "MODULE"
@@ -98,23 +97,6 @@ func (rv *ReturnValue) Inspect() string { return rv.Value.Inspect() }
 
 // Class reurns the class of the wrapped object
 func (rv *ReturnValue) Class() RubyClass { return rv.Value.Class() }
-
-// Error represents the old way of marking something within the evaluation
-// phase as error. It is obsolete and should be replaced by a real exception.
-//
-// This object will go away soon. Don't depend on it.
-type Error struct {
-	Message string
-}
-
-// Type returns ERROR_OBJ
-func (e *Error) Type() Type { return ERROR_OBJ }
-
-// Inspect returns the wrapped message preprended with 'ERROR: '
-func (e *Error) Inspect() string { return "ERROR: " + e.Message }
-
-// Class returns nil
-func (e *Error) Class() RubyClass { return nil }
 
 // A Function represents a user defined function. It is no real Ruby object.
 type Function struct {


### PR DESCRIPTION
Just a cleanup of leftovers from early days of the interpreter.