### PR TITLE
Remove builtin functions

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -85,6 +85,7 @@ func Eval(node ast.Node, env object.Environment) (object.RubyObject, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		if function, ok := env.Get(node.Function.Value); ok {
 			return applyFunction(function, args)
 		}
@@ -142,8 +143,6 @@ func evalProgram(stmts []ast.Statement, env object.Environment) (object.RubyObje
 		switch result := result.(type) {
 		case *object.ReturnValue:
 			return result.Value, nil
-		case *object.Builtin:
-			return result.Fn(), nil
 		}
 
 	}
@@ -373,8 +372,6 @@ func applyFunction(fn object.RubyObject, args []object.RubyObject) (object.RubyO
 			return nil, err
 		}
 		return unwrapReturnValue(evaluated), nil
-	case *object.Builtin:
-		return fn.Fn(args...), nil
 	default:
 		return nil, object.NewSyntaxError(fmt.Errorf("not a function: %s", fn.Type()))
 	}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -372,39 +372,6 @@ func TestSymbolLiteral(t *testing.T) {
 	}
 }
 
-func TestBuiltinFunctions(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected interface{}
-	}{
-		{`puts;`, nil},
-		{`puts "foo";`, nil},
-	}
-
-	for _, tt := range tests {
-		evaluated, err := testEval(tt.input, object.NewMainEnvironment())
-		checkError(t, err)
-
-		switch expected := tt.expected.(type) {
-		case int:
-			testIntegerObject(t, evaluated, int64(expected))
-		case nil:
-			testNilObject(t, evaluated)
-		case string:
-			ok := IsError(evaluated)
-			if !ok {
-				t.Errorf("object is not Error. got=%T (%+v)",
-					evaluated, evaluated)
-				continue
-			}
-			if evaluated.Inspect() != expected {
-				t.Errorf("wrong error message. expected=%q, got=%q",
-					expected, evaluated.Inspect())
-			}
-		}
-	}
-}
-
 func TestMethodCalls(t *testing.T) {
 	input := "x = 2; x.foo :bar"
 

--- a/object/environment.go
+++ b/object/environment.go
@@ -5,7 +5,7 @@ var classes = NewEnvironment()
 // NewMainEnvironment returns a new Environment populated with all Ruby classes
 // and the Kernel functions
 func NewMainEnvironment() Environment {
-	env := kernelFunctions.Clone()
+	env := classes.Clone()
 	env.Set("self", &Self{&Object{}})
 	env.SetGlobal("$LOADED_FEATURES", NewArray())
 	return env

--- a/object/environment.go
+++ b/object/environment.go
@@ -5,7 +5,7 @@ var classes = NewEnvironment()
 // NewMainEnvironment returns a new Environment populated with all Ruby classes
 // and the Kernel functions
 func NewMainEnvironment() Environment {
-	env := kernelFunctions
+	env := kernelFunctions.Clone()
 	env.Set("self", &Self{&Object{}})
 	env.SetGlobal("$LOADED_FEATURES", NewArray())
 	return env
@@ -37,6 +37,11 @@ type Environment interface {
 	SetGlobal(name string, val RubyObject) RubyObject
 	// Outer returns the parent environment
 	Outer() Environment
+	// Clone returns a copy of the environment. It will shallow copy its values
+	//
+	// Note that clone will also not set its outer env, so calls to Outer will
+	// return nil on cloned Environments
+	Clone() Environment
 }
 
 type environment struct {
@@ -81,6 +86,10 @@ func (e *environment) Enclose(outer Environment) Environment {
 	env := e.clone()
 	env.outer = outer
 	return env
+}
+
+func (e *environment) Clone() Environment {
+	return e.clone()
 }
 
 func (e *environment) clone() *environment {

--- a/object/kernel.go
+++ b/object/kernel.go
@@ -3,21 +3,9 @@ package object
 import "fmt"
 
 var kernelModule = newModule("Kernel", kernelMethodSet)
-var kernelFunctions = NewEnclosedEnvironment(classes.Clone())
 
 func init() {
 	classes.Set("Kernel", kernelModule)
-	kernelFunctions.Set("puts", &Builtin{
-		Fn: func(args ...RubyObject) RubyObject {
-			out := ""
-			for _, arg := range args {
-				out += arg.Inspect()
-			}
-			fmt.Println(out)
-			return NIL
-		},
-	},
-	)
 }
 
 var kernelMethodSet = map[string]RubyMethod{

--- a/object/kernel.go
+++ b/object/kernel.go
@@ -3,7 +3,7 @@ package object
 import "fmt"
 
 var kernelModule = newModule("Kernel", kernelMethodSet)
-var kernelFunctions = NewEnclosedEnvironment(classes)
+var kernelFunctions = NewEnclosedEnvironment(classes.Clone())
 
 func init() {
 	classes.Set("Kernel", kernelModule)

--- a/object/ruby_object.go
+++ b/object/ruby_object.go
@@ -35,7 +35,6 @@ const (
 	EXCEPTION_CLASS_OBJ    Type = "EXCEPTION_CLASS"
 	MODULE_OBJ             Type = "MODULE"
 	MODULE_CLASS_OBJ       Type = "MODULE_CLASS"
-	BUILTIN_OBJ            Type = "BUILTIN"
 	SELF                   Type = "SELF"
 )
 
@@ -61,28 +60,6 @@ type RubyClassObject interface {
 	RubyObject
 	RubyClass
 }
-
-// A BuiltinFunction represents a function
-type BuiltinFunction func(args ...RubyObject) RubyObject
-
-// Builtin represents a builtin within the interpreter. It holds a function
-// which can be called directly. It is no real Ruby object.
-//
-// Ruby does not have any builtin functions as everything is bound to an object.
-//
-// This object will go away soon. Don't depend on it.
-type Builtin struct {
-	Fn BuiltinFunction
-}
-
-// Type returns BUILTIN_OBJ
-func (b *Builtin) Type() Type { return BUILTIN_OBJ }
-
-// Inspect returns 'buitin function'
-func (b *Builtin) Inspect() string { return "builtin function" }
-
-// Class returns nil
-func (b *Builtin) Class() RubyClass { return nil }
 
 // ReturnValue represents a wrapper object for a return statement. It is no
 // real Ruby object and only used within the interpreter evaluation


### PR DESCRIPTION
This removes builtin functions as they were a workaround for a missing main
object which behaves as self in the toplevel context.

This PR is based on the work done in PR [#12](https://github.com/goruby/goruby/pull/12) as it needs self.