### PR TITLE
Make objects extendable

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -205,7 +205,7 @@ end
 
 	for _, tt := range tests {
 		env := object.NewEnvironment()
-		env.Set("self", &object.Object{})
+		env.Set("self", &object.Self{&object.Object{}})
 		evaluated := testEval(tt.input, env)
 
 		ok := IsError(evaluated)
@@ -269,7 +269,9 @@ func TestFunctionObject(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		evaluated := testEval(tt.input)
+		env := object.NewEnvironment()
+		env.Set("self", &object.Self{&object.Object{}})
+		evaluated := testEval(tt.input, env)
 		fn, ok := evaluated.(*object.Function)
 		if !ok {
 			t.Fatalf("object is not Function. got=%T (%+v)", evaluated, evaluated)
@@ -310,7 +312,9 @@ func TestFunctionApplication(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		testIntegerObject(t, testEval(tt.input), tt.expected)
+		env := object.NewEnvironment()
+		env.Set("self", &object.Self{&object.Object{}})
+		testIntegerObject(t, testEval(tt.input, env), tt.expected)
 	}
 }
 

--- a/object/eigenclass.go
+++ b/object/eigenclass.go
@@ -1,6 +1,6 @@
 package object
 
-func newEigenclass(wrappedClass RubyClass, methods map[string]RubyMethod) RubyClassObject {
+func newEigenclass(wrappedClass RubyClass, methods map[string]RubyMethod) *eigenclass {
 	return &eigenclass{methods: methods, wrappedClass: wrappedClass}
 }
 
@@ -28,4 +28,7 @@ func (e *eigenclass) SuperClass() RubyClass {
 		return e.wrappedClass
 	}
 	return objectClass
+}
+func (e *eigenclass) addMethod(name string, method RubyMethod) {
+	e.methods[name] = method
 }

--- a/object/module_test.go
+++ b/object/module_test.go
@@ -31,6 +31,35 @@ func TestModuleAncestors(t *testing.T) {
 			t.Fail()
 		}
 	})
+	t.Run("class with mixed in modules", func(t *testing.T) {
+		context := mixin(
+			&class{name: "BasicObjectAsParent", superClass: basicObjectClass},
+			kernelModule,
+		)
+
+		result := moduleAncestors(context)
+
+		array, ok := result.(*Array)
+		if !ok {
+			t.Logf("Expected result to be an Array, got %T", result)
+			t.FailNow()
+		}
+
+		expectedAncestors := 3
+
+		if len(array.Elements) != expectedAncestors {
+			t.Logf("Expected %d ancestors, got %d", expectedAncestors, len(array.Elements))
+			t.Fail()
+		}
+
+		expected := fmt.Sprintf("[%s]", strings.Join([]string{"BasicObjectAsParent", "Kernel", "BasicObject"}, ", "))
+		actual := fmt.Sprintf("%s", array.Inspect())
+
+		if expected != actual {
+			t.Logf("Expected ancestors to equal %s, got %s", expected, actual)
+			t.Fail()
+		}
+	})
 	t.Run("core class hierarchies", func(t *testing.T) {
 		tests := []struct {
 			class             RubyClassObject

--- a/object/send.go
+++ b/object/send.go
@@ -27,6 +27,28 @@ func Send(context RubyObject, method string, args ...RubyObject) RubyObject {
 	return methodMissing(context, methodMissingArgs...)
 }
 
+// AddMethod adds a method to a given object. It returns the object with the modified method set
+func AddMethod(context RubyObject, methodName string, method *Function) RubyObject {
+	objectToExtend := context
+	self, contextIsSelf := context.(*Self)
+	if contextIsSelf {
+		objectToExtend = self.RubyObject
+	}
+	extended, ok := objectToExtend.(*extendedObject)
+	if !ok {
+		extended = &extendedObject{
+			RubyObject: context,
+			class:      newEigenclass(context.Class(), map[string]RubyMethod{}),
+		}
+	}
+	extended.addMethod(methodName, method)
+	if contextIsSelf {
+		self.RubyObject = extended
+		return self
+	}
+	return extended
+}
+
 func methodMissing(context RubyObject, args ...RubyObject) RubyObject {
 	class := context.Class()
 


### PR DESCRIPTION
This adds the possibility to add methods to objects. The current benefit is
just in adding self defined toplevel functions to the main object so that they
can be called.

This will further enable us to define classes and modules and extend existing
objects via `Module#extend`.

This PR depends on #12 