### PR TITLE
Make eval and object packages more idiomatic Go

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Eval evaluates the given node and traverses recursive over its children
-func Eval(node ast.Node, env object.Environment) object.RubyObject {
+func Eval(node ast.Node, env object.Environment) (object.RubyObject, error) {
 	switch node := node.(type) {
 
 	// Statements
@@ -22,11 +22,11 @@ func Eval(node ast.Node, env object.Environment) object.RubyObject {
 	case *ast.ExpressionStatement:
 		return Eval(node.Expression, env)
 	case *ast.ReturnStatement:
-		val := Eval(node.ReturnValue, env)
+		val, err := Eval(node.ReturnValue, env)
 		if IsError(val) {
-			return val
+			return val, err
 		}
-		return &object.ReturnValue{Value: val}
+		return &object.ReturnValue{Value: val}, nil
 	case *ast.BlockStatement:
 		return evalBlockStatement(node, env)
 
@@ -34,20 +34,20 @@ func Eval(node ast.Node, env object.Environment) object.RubyObject {
 
 	// Literals
 	case (*ast.IntegerLiteral):
-		return object.NewInteger(node.Value)
+		return object.NewInteger(node.Value), nil
 	case (*ast.Boolean):
-		return nativeBoolToBooleanObject(node.Value)
+		return nativeBoolToBooleanObject(node.Value), nil
 	case (*ast.Nil):
-		return object.NIL
+		return object.NIL, nil
 	case (*ast.Self):
 		self, _ := env.Get("self")
-		return self
+		return self, nil
 	case *ast.Identifier:
 		return evalIdentifier(node, env)
 	case *ast.StringLiteral:
-		return &object.String{Value: node.Value}
+		return &object.String{Value: node.Value}, nil
 	case *ast.SymbolLiteral:
-		return &object.Symbol{Value: node.Value}
+		return &object.Symbol{Value: node.Value}, nil
 	case *ast.FunctionLiteral:
 		params := node.Parameters
 		body := node.Body
@@ -59,61 +59,61 @@ func Eval(node ast.Node, env object.Environment) object.RubyObject {
 			CallFn:     applyFunction,
 		}
 		object.AddMethod(context, node.Name.Value, function)
-		return function
+		return function, nil
 	case *ast.ArrayLiteral:
-		elements := evalExpressions(node.Elements, env)
+		elements, err := evalExpressions(node.Elements, env)
 		if len(elements) == 1 && IsError(elements[0]) {
-			return elements[0]
+			return elements[0], err
 		}
-		return &object.Array{Elements: elements}
+		return &object.Array{Elements: elements}, nil
 	case *ast.VariableAssignment:
-		val := Eval(node.Value, env)
+		val, err := Eval(node.Value, env)
 		if IsError(val) {
-			return val
+			return val, err
 		}
 		env.Set(node.Name.Value, val)
-		return val
+		return val, nil
 	case *ast.ContextCallExpression:
-		context := Eval(node.Context, env)
+		context, err := Eval(node.Context, env)
 		if IsError(context) {
-			return context
+			return context, err
 		}
 		if context == nil {
 			context, _ = env.Get("self")
 		}
-		args := evalExpressions(node.Arguments, env)
+		args, err := evalExpressions(node.Arguments, env)
 		if len(args) == 1 && IsError(args[0]) {
-			return args[0]
+			return args[0], err
 		}
 		if function, ok := env.Get(node.Function.Value); ok {
-			return applyFunction(function, args)
+			return applyFunction(function, args), nil
 		}
-		return object.Send(context, node.Function.Value, args...)
+		return object.Send(context, node.Function.Value, args...), nil
 	case *ast.IndexExpression:
-		left := Eval(node.Left, env)
+		left, err := Eval(node.Left, env)
 		if IsError(left) {
-			return left
+			return left, err
 		}
-		index := Eval(node.Index, env)
+		index, err := Eval(node.Index, env)
 		if IsError(index) {
-			return index
+			return index, err
 		}
 		return evalIndexExpression(left, index)
 	case *ast.PrefixExpression:
-		right := Eval(node.Right, env)
+		right, err := Eval(node.Right, env)
 		if IsError(right) {
-			return right
+			return right, err
 		}
 		return evalPrefixExpression(node.Operator, right)
 	case *ast.InfixExpression:
-		left := Eval(node.Left, env)
+		left, err := Eval(node.Left, env)
 		if IsError(left) {
-			return left
+			return left, err
 		}
 
-		right := Eval(node.Right, env)
+		right, err := Eval(node.Right, env)
 		if IsError(right) {
-			return right
+			return right, err
 		}
 		return evalInfixExpression(node.Operator, left, right)
 	case *ast.IfExpression:
@@ -121,46 +121,48 @@ func Eval(node ast.Node, env object.Environment) object.RubyObject {
 	case *ast.RequireExpression:
 		return evalRequireExpression(node, env)
 	case nil:
-		return nil
+		return nil, nil
 	default:
-		return object.NewException("Unknown AST: %T", node)
+		err := object.NewException("Unknown AST: %T", node)
+		return err, err
 	}
 
 }
 
-func evalProgram(stmts []ast.Statement, env object.Environment) object.RubyObject {
+func evalProgram(stmts []ast.Statement, env object.Environment) (object.RubyObject, error) {
 	var result object.RubyObject
+	var err error
 	for _, statement := range stmts {
-		result = Eval(statement, env)
+		result, err = Eval(statement, env)
 
 		switch result := result.(type) {
 		case *object.ReturnValue:
-			return result.Value
+			return result.Value, nil
 		case *object.Builtin:
-			return result.Fn()
+			return result.Fn(), nil
 		}
 
 		if IsError(result) {
-			return result
+			return result, err
 		}
 	}
-	return result
+	return result, nil
 }
 
-func evalExpressions(exps []ast.Expression, env object.Environment) []object.RubyObject {
+func evalExpressions(exps []ast.Expression, env object.Environment) ([]object.RubyObject, error) {
 	var result []object.RubyObject
 
 	for _, e := range exps {
-		evaluated := Eval(e, env)
+		evaluated, err := Eval(e, env)
 		if IsError(evaluated) {
-			return []object.RubyObject{evaluated}
+			return []object.RubyObject{evaluated}, err
 		}
 		result = append(result, evaluated)
 	}
-	return result
+	return result, nil
 }
 
-func evalRequireExpression(expr *ast.RequireExpression, env object.Environment) object.RubyObject {
+func evalRequireExpression(expr *ast.RequireExpression, env object.Environment) (object.RubyObject, error) {
 	filename := expr.Name.Value
 	if !strings.HasSuffix(filename, "rb") {
 		filename += ".rb"
@@ -182,32 +184,35 @@ func evalRequireExpression(expr *ast.RequireExpression, env object.Environment) 
 		}
 	}
 	if loaded {
-		return object.FALSE
+		return object.FALSE, nil
 	}
 
 	arr.Elements = append(arr.Elements, &object.String{Value: filename})
 	file, err := ioutil.ReadFile(filename)
 	if os.IsNotExist(err) {
-		return object.NewLoadError(expr.Name.Value)
+		errObj := object.NewLoadError(expr.Name.Value)
+		return errObj, errObj
 	}
 	l := lexer.New(string(file))
 	p := parser.New(l)
 	prog, err := p.ParseProgram()
 	if err != nil {
-		return object.NewSyntaxError(err.Error())
+		errObj := object.NewSyntaxError(err.Error())
+		return errObj, errObj
 	}
 	Eval(prog, env)
-	return object.TRUE
+	return object.TRUE, nil
 }
 
-func evalPrefixExpression(operator string, right object.RubyObject) object.RubyObject {
+func evalPrefixExpression(operator string, right object.RubyObject) (object.RubyObject, error) {
 	switch operator {
 	case "!":
-		return evalBangOperatorExpression(right)
+		return evalBangOperatorExpression(right), nil
 	case "-":
 		return evalMinusPrefixOperatorExpression(right)
 	default:
-		return object.NewException("unknown operator: %s%s", operator, right.Type())
+		err := object.NewException("unknown operator: %s%s", operator, right.Type())
+		return err, err
 	}
 }
 
@@ -224,88 +229,95 @@ func evalBangOperatorExpression(right object.RubyObject) object.RubyObject {
 	}
 }
 
-func evalMinusPrefixOperatorExpression(right object.RubyObject) object.RubyObject {
+func evalMinusPrefixOperatorExpression(right object.RubyObject) (object.RubyObject, error) {
 	switch right := right.(type) {
 	case *object.Integer:
-		return &object.Integer{Value: -right.Value}
+		return &object.Integer{Value: -right.Value}, nil
 	default:
-		return object.NewException("unknown operator: -%s", right.Type())
+		err := object.NewException("unknown operator: -%s", right.Type())
+		return err, err
 	}
 }
 
-func evalInfixExpression(operator string, left, right object.RubyObject) object.RubyObject {
+func evalInfixExpression(operator string, left, right object.RubyObject) (object.RubyObject, error) {
 	switch {
 	case left.Type() == object.INTEGER_OBJ && right.Type() == object.INTEGER_OBJ:
 		return evalIntegerInfixExpression(operator, left, right)
 	case left.Type() == object.STRING_OBJ && right.Type() == object.STRING_OBJ:
 		return evalStringInfixExpression(operator, left, right)
 	case operator == "==":
-		return nativeBoolToBooleanObject(left == right)
+		return nativeBoolToBooleanObject(left == right), nil
 	case operator == "!=":
-		return nativeBoolToBooleanObject(left != right)
+		return nativeBoolToBooleanObject(left != right), nil
 	case left.Type() != right.Type():
-		return object.NewException("type mismatch: %s %s %s", left.Type(), operator, right.Type())
+		err := object.NewException("type mismatch: %s %s %s", left.Type(), operator, right.Type())
+		return err, err
 	default:
-		return object.NewException("unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		err := object.NewException("unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return err, err
 	}
 }
 
-func evalIntegerInfixExpression(operator string, left, right object.RubyObject) object.RubyObject {
+func evalIntegerInfixExpression(operator string, left, right object.RubyObject) (object.RubyObject, error) {
 	leftVal := left.(*object.Integer).Value
 	rightVal := right.(*object.Integer).Value
 	switch operator {
 	case "+":
-		return &object.Integer{Value: leftVal + rightVal}
+		return &object.Integer{Value: leftVal + rightVal}, nil
 	case "-":
-		return &object.Integer{Value: leftVal - rightVal}
+		return &object.Integer{Value: leftVal - rightVal}, nil
 	case "*":
-		return &object.Integer{Value: leftVal * rightVal}
+		return &object.Integer{Value: leftVal * rightVal}, nil
 	case "/":
-		return &object.Integer{Value: leftVal / rightVal}
+		return &object.Integer{Value: leftVal / rightVal}, nil
 	case "<":
-		return nativeBoolToBooleanObject(leftVal < rightVal)
+		return nativeBoolToBooleanObject(leftVal < rightVal), nil
 	case ">":
-		return nativeBoolToBooleanObject(leftVal > rightVal)
+		return nativeBoolToBooleanObject(leftVal > rightVal), nil
 	case "==":
-		return nativeBoolToBooleanObject(leftVal == rightVal)
+		return nativeBoolToBooleanObject(leftVal == rightVal), nil
 	case "!=":
-		return nativeBoolToBooleanObject(leftVal != rightVal)
+		return nativeBoolToBooleanObject(leftVal != rightVal), nil
 	default:
-		return object.NewException("unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		err := object.NewException("unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return err, err
 	}
 }
 
 func evalStringInfixExpression(
 	operator string,
-	left, right object.RubyObject) object.RubyObject {
+	left, right object.RubyObject,
+) (object.RubyObject, error) {
 	if operator != "+" {
-		return object.NewException("unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		err := object.NewException("unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return err, err
 	}
 	leftVal := left.(*object.String).Value
 	rightVal := right.(*object.String).Value
-	return &object.String{Value: leftVal + rightVal}
+	return &object.String{Value: leftVal + rightVal}, nil
 }
 
-func evalIfExpression(ie *ast.IfExpression, env object.Environment) object.RubyObject {
-	condition := Eval(ie.Condition, env)
+func evalIfExpression(ie *ast.IfExpression, env object.Environment) (object.RubyObject, error) {
+	condition, err := Eval(ie.Condition, env)
 	if IsError(condition) {
-		return condition
+		return condition, err
 	}
 	if isTruthy(condition) {
 		return Eval(ie.Consequence, env)
 	} else if ie.Alternative != nil {
 		return Eval(ie.Alternative, env)
 	} else {
-		return object.NIL
+		return object.NIL, nil
 	}
 }
 
-func evalIndexExpression(left, index object.RubyObject) object.RubyObject {
+func evalIndexExpression(left, index object.RubyObject) (object.RubyObject, error) {
 	switch {
 	case left.Type() == object.ARRAY_OBJ && index.Type() == object.INTEGER_OBJ:
-		return evalArrayIndexExpression(left, index)
+		return evalArrayIndexExpression(left, index), nil
 	default:
-		return object.NewException("index operator not supported: %s", left.Type())
+		err := object.NewException("index operator not supported: %s", left.Type())
+		return err, err
 	}
 }
 
@@ -319,38 +331,40 @@ func evalArrayIndexExpression(array, index object.RubyObject) object.RubyObject 
 	return arrayObject.Elements[idx]
 }
 
-func evalBlockStatement(block *ast.BlockStatement, env object.Environment) object.RubyObject {
+func evalBlockStatement(block *ast.BlockStatement, env object.Environment) (object.RubyObject, error) {
 	var result object.RubyObject
+	var err error
 	for _, statement := range block.Statements {
-		result = Eval(statement, env)
+		result, err = Eval(statement, env)
 		if result != nil {
 			rt := result.Type()
 			if rt == object.RETURN_VALUE_OBJ || IsError(result) {
-				return result
+				return result, err
 			}
 
 		}
 	}
-	return result
+	return result, nil
 }
 
-func evalIdentifier(node *ast.Identifier, env object.Environment) object.RubyObject {
+func evalIdentifier(node *ast.Identifier, env object.Environment) (object.RubyObject, error) {
 	val, ok := env.Get(node.Value)
 	if ok {
 		if fn, ok := val.(*object.Function); ok {
 			if len(fn.Parameters) != 0 {
-				return val
+				return val, nil
 			}
-			return applyFunction(fn, []object.RubyObject{})
+			return applyFunction(fn, []object.RubyObject{}), nil
 		}
-		return val
+		return val, nil
 	}
 	self, _ := env.Get("self")
 	val = object.Send(self, node.Value)
 	if IsError(val) {
-		return object.NewNameError(self, node.Value)
+		err := object.NewNameError(self, node.Value)
+		return err, err
 	}
-	return val
+	return val, nil
 }
 
 func applyFunction(fn object.RubyObject, args []object.RubyObject) object.RubyObject {
@@ -360,7 +374,7 @@ func applyFunction(fn object.RubyObject, args []object.RubyObject) object.RubyOb
 			return object.NewWrongNumberOfArgumentsError(len(fn.Parameters), len(args))
 		}
 		extendedEnv := extendFunctionEnv(fn, args)
-		evaluated := Eval(fn.Body, extendedEnv)
+		evaluated, _ := Eval(fn.Body, extendedEnv)
 		return unwrapReturnValue(evaluated)
 	case *object.Builtin:
 		return fn.Fn(args...)

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -642,7 +642,8 @@ func testEval(input string, context ...object.Environment) object.RubyObject {
 	if err != nil {
 		return object.NewSyntaxError(err.Error())
 	}
-	return Eval(program, env)
+	evaluated, err := Eval(program, env)
+	return evaluated
 }
 
 func testBooleanObject(t *testing.T, obj object.RubyObject, expected bool) bool {

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -1,8 +1,6 @@
 package interpreter
 
 import (
-	"fmt"
-
 	"github.com/goruby/goruby/ast"
 	"github.com/goruby/goruby/evaluator"
 	"github.com/goruby/goruby/lexer"
@@ -31,9 +29,9 @@ func (i *interpreter) Interpret(input string) (object.RubyObject, error) {
 	if err != nil {
 		return nil, err
 	}
-	evaluated := evaluator.Eval(node, i.environment)
+	evaluated, err := evaluator.Eval(node, i.environment)
 	if evaluator.IsError(evaluated) {
-		return nil, fmt.Errorf(evaluated.Inspect())
+		return nil, err
 	}
 	return evaluated, nil
 }

--- a/object/basic_object.go
+++ b/object/basic_object.go
@@ -19,8 +19,8 @@ func (b *basicObject) Type() Type { return BASIC_OBJECT_OBJ }
 func (b *basicObject) Class() RubyClass { return basicObjectClass }
 
 var basicObjectClassMethods = map[string]RubyMethod{
-	"new": publicMethod(func(context RubyObject, args ...RubyObject) RubyObject {
-		return &basicObject{}
+	"new": publicMethod(func(context RubyObject, args ...RubyObject) (RubyObject, error) {
+		return &basicObject{}, nil
 	}),
 }
 
@@ -28,15 +28,13 @@ var basicObjectMethods = map[string]RubyMethod{
 	"method_missing": privateMethod(basicObjectMethodMissing),
 }
 
-func basicObjectMethodMissing(context RubyObject, args ...RubyObject) RubyObject {
+func basicObjectMethodMissing(context RubyObject, args ...RubyObject) (RubyObject, error) {
 	if len(args) < 1 {
-		// TODO: can we protect against this
-		panic("wrong number of call arguments for method_missing")
+		return nil, NewWrongNumberOfArgumentsError(1, 0)
 	}
 	method, ok := args[0].(*Symbol)
 	if !ok {
-		// TODO: can we protect against this?
-		panic("wrong call argument for method_missing")
+		return nil, NewImplicitConversionTypeError(method, args[0])
 	}
-	return NewNoMethodError(context, method.Value)
+	return nil, NewNoMethodError(context, method.Value)
 }

--- a/object/basic_object_test.go
+++ b/object/basic_object_test.go
@@ -1,17 +1,15 @@
 package object
 
 import (
-	"reflect"
 	"testing"
 )
 
 func TestBasicObjectMethodMissing(t *testing.T) {
-	result := basicObjectMethodMissing(NIL, &Symbol{"foo"})
+	result, err := basicObjectMethodMissing(NIL, &Symbol{"foo"})
+
+	checkResult(t, result, nil)
 
 	expected := NewNoMethodError(NIL, "foo")
 
-	if !reflect.DeepEqual(expected, result) {
-		t.Logf("Expected result to equal\n%+#v\n\tgot\n%+#v\n", expected, result)
-		t.Fail()
-	}
+	checkError(t, err, expected)
 }

--- a/object/class.go
+++ b/object/class.go
@@ -48,14 +48,14 @@ var classMethods = map[string]RubyMethod{
 	"superclass": withArity(0, publicMethod(classSuperclass)),
 }
 
-func classSuperclass(context RubyObject, args ...RubyObject) RubyObject {
+func classSuperclass(context RubyObject, args ...RubyObject) (RubyObject, error) {
 	class := context.(RubyClass)
 	superclass := class.SuperClass()
 	if superclass == nil {
-		return NIL
+		return NIL, nil
 	}
 	if mixin, ok := superclass.(*methodSet); ok {
-		return mixin.RubyClassObject
+		return mixin.RubyClassObject, nil
 	}
-	return superclass.(RubyObject)
+	return superclass.(RubyObject), nil
 }

--- a/object/class_test.go
+++ b/object/class_test.go
@@ -95,7 +95,11 @@ func TestClassSuperclass(t *testing.T) {
 	t.Run("anything else than BasicObject", func(t *testing.T) {
 		context := &class{superClass: objectClass}
 
-		result := classSuperclass(context)
+		result, err := classSuperclass(context)
+		if err != nil {
+			t.Logf("Expected no error, got %T:%v\n", err, err)
+			t.Fail()
+		}
 
 		_, ok := result.(*class)
 		if !ok {
@@ -106,7 +110,11 @@ func TestClassSuperclass(t *testing.T) {
 	t.Run("BasicObject", func(t *testing.T) {
 		context := basicObjectClass
 
-		result := classSuperclass(context)
+		result, err := classSuperclass(context)
+		if err != nil {
+			t.Logf("Expected no error, got %T:%v\n", err, err)
+			t.Fail()
+		}
 
 		_, ok := result.(*nilObject)
 		if !ok {
@@ -117,7 +125,11 @@ func TestClassSuperclass(t *testing.T) {
 	t.Run("Eigenclass", func(t *testing.T) {
 		context := &class{superClass: newEigenclass(objectClass, nil)}
 
-		result := classSuperclass(context)
+		result, err := classSuperclass(context)
+		if err != nil {
+			t.Logf("Expected no error, got %T:%v\n", err, err)
+			t.Fail()
+		}
 
 		_, ok := result.(*eigenclass)
 		if !ok {

--- a/object/exception.go
+++ b/object/exception.go
@@ -40,12 +40,12 @@ func formatException(exception RubyObject, message string) string {
 // NewException creates a new exception with the given message template and
 //uses fmt.Sprintf to interpolate the args into messageinto message.
 func NewException(message string, args ...interface{}) *Exception {
-	return &Exception{Message: fmt.Sprintf(message, args...)}
+	return &Exception{&exception{Message: fmt.Sprintf(message, args...)}}
 }
 
 // Exception represents a basic exception
 type Exception struct {
-	Message string
+	*exception
 }
 
 // Type returns the type of the RubyObject
@@ -61,14 +61,20 @@ var exceptionClassMethods = map[string]RubyMethod{}
 
 var exceptionMethods = map[string]RubyMethod{}
 
+type exception struct {
+	Message string
+}
+
+func (e *exception) Error() string { return e.Message }
+
 // NewStandardError returns a StandardError with the given message
 func NewStandardError(message string) *StandardError {
-	return &StandardError{Message: message}
+	return &StandardError{&exception{Message: message}}
 }
 
 // StandardError is the default class for rescue blocks
 type StandardError struct {
-	Message string
+	*exception
 }
 
 // Type returns EXCEPTION_OBJ
@@ -83,13 +89,15 @@ func (e *StandardError) Class() RubyClass { return standardErrorClass }
 // NewZeroDivisionError returns a new ZeroDivisionError with the default message
 func NewZeroDivisionError() *ZeroDivisionError {
 	return &ZeroDivisionError{
-		Message: "divided by 0",
+		&exception{
+			Message: "divided by 0",
+		},
 	}
 }
 
 // ZeroDivisionError represents an arithmethic error when dividing through 0
 type ZeroDivisionError struct {
-	Message string
+	*exception
 }
 
 // Type returns EXCEPTION_OBJ
@@ -104,17 +112,19 @@ func (e *ZeroDivisionError) Class() RubyClass { return zeroDivisionErrorClass }
 // NewWrongNumberOfArgumentsError returns an ArgumentError populated with the default message
 func NewWrongNumberOfArgumentsError(expected, actual int) *ArgumentError {
 	return &ArgumentError{
-		Message: fmt.Sprintf(
-			"wrong number of arguments (given %d, expected %d)",
-			actual,
-			expected,
-		),
+		&exception{
+			Message: fmt.Sprintf(
+				"wrong number of arguments (given %d, expected %d)",
+				actual,
+				expected,
+			),
+		},
 	}
 }
 
 // ArgumentError represents an error in method call arguments
 type ArgumentError struct {
-	Message string
+	*exception
 }
 
 // Type returns EXCEPTION_OBJ
@@ -129,18 +139,20 @@ func (e *ArgumentError) Class() RubyClass { return argumentErrorClass }
 // NewNameError returns a NameError with the default message for undefined names
 func NewNameError(context RubyObject, name string) *NameError {
 	return &NameError{
-		Message: fmt.Sprintf(
-			"undefined local variable or method `%s' for %s:%s",
-			name,
-			context.Inspect(),
-			context.Class().(RubyObject).Inspect(),
-		),
+		&exception{
+			Message: fmt.Sprintf(
+				"undefined local variable or method `%s' for %s:%s",
+				name,
+				context.Inspect(),
+				context.Class().(RubyObject).Inspect(),
+			),
+		},
 	}
 }
 
 // A NameError represents an error accessing an identifier unknown to the environment
 type NameError struct {
-	Message string
+	*exception
 }
 
 // Type returns EXCEPTION_OBJ
@@ -155,30 +167,34 @@ func (e *NameError) Class() RubyClass { return nameErrorClass }
 // NewNoMethodError returns a NoMethodError with the default message for undefined methods
 func NewNoMethodError(context RubyObject, method string) *NoMethodError {
 	return &NoMethodError{
-		Message: fmt.Sprintf(
-			"undefined method `%s' for %s:%s",
-			method,
-			context.Inspect(),
-			context.Class().(RubyObject).Inspect(),
-		),
+		&exception{
+			Message: fmt.Sprintf(
+				"undefined method `%s' for %s:%s",
+				method,
+				context.Inspect(),
+				context.Class().(RubyObject).Inspect(),
+			),
+		},
 	}
 }
 
 // NewPrivateNoMethodError returns a NoMethodError with the default message for private methods
 func NewPrivateNoMethodError(context RubyObject, method string) *NoMethodError {
 	return &NoMethodError{
-		Message: fmt.Sprintf(
-			"private method `%s' called for %s:%s",
-			method,
-			context.Inspect(),
-			context.Class().(RubyObject).Inspect(),
-		),
+		&exception{
+			Message: fmt.Sprintf(
+				"private method `%s' called for %s:%s",
+				method,
+				context.Inspect(),
+				context.Class().(RubyObject).Inspect(),
+			),
+		},
 	}
 }
 
 // NoMethodError represents an error finding a fitting method on an object
 type NoMethodError struct {
-	Message string
+	*exception
 }
 
 // Type returns EXCEPTION_OBJ
@@ -193,28 +209,32 @@ func (e *NoMethodError) Class() RubyClass { return noMethodErrorClass }
 // NewCoercionTypeError returns a TypeError with the default message for coercing errors
 func NewCoercionTypeError(expected, actual RubyObject) *TypeError {
 	return &TypeError{
-		Message: fmt.Sprintf(
-			"%s can't be coerced into %s",
-			reflect.TypeOf(actual).Elem().Name(),
-			reflect.TypeOf(expected).Elem().Name(),
-		),
+		&exception{
+			Message: fmt.Sprintf(
+				"%s can't be coerced into %s",
+				reflect.TypeOf(actual).Elem().Name(),
+				reflect.TypeOf(expected).Elem().Name(),
+			),
+		},
 	}
 }
 
 // NewImplicitConversionTypeError returns a TypeError with the default message for impossible implicit conversions
 func NewImplicitConversionTypeError(expected, actual RubyObject) *TypeError {
 	return &TypeError{
-		Message: fmt.Sprintf(
-			"no implicit conversion of %s into %s",
-			reflect.TypeOf(actual).Elem().Name(),
-			reflect.TypeOf(expected).Elem().Name(),
-		),
+		&exception{
+			Message: fmt.Sprintf(
+				"no implicit conversion of %s into %s",
+				reflect.TypeOf(actual).Elem().Name(),
+				reflect.TypeOf(expected).Elem().Name(),
+			),
+		},
 	}
 }
 
 // TypeError represents an error when the given type does not fit in the given context
 type TypeError struct {
-	Message string
+	*exception
 }
 
 // Type returns EXCEPTION_OBJ
@@ -226,9 +246,14 @@ func (e *TypeError) Inspect() string { return formatException(e, e.Message) }
 // Class returns typeErrorClass
 func (e *TypeError) Class() RubyClass { return typeErrorClass }
 
+// NewScriptError returns a new script error with the provided message
+func NewScriptError(format string, args ...interface{}) *ScriptError {
+	return &ScriptError{&exception{Message: fmt.Sprintf(format, args...)}}
+}
+
 // ScriptError represetns an error in the loaded script
 type ScriptError struct {
-	Message string
+	*exception
 }
 
 // Type returns EXCEPTION_OBJ
@@ -243,16 +268,18 @@ func (e *ScriptError) Class() RubyClass { return scriptErrorClass }
 // NewLoadError returns a new LoadError with the default message
 func NewLoadError(filepath string) *LoadError {
 	return &LoadError{
-		Message: fmt.Sprintf(
-			"no such file to load -- %s",
-			filepath,
-		),
+		&exception{
+			Message: fmt.Sprintf(
+				"no such file to load -- %s",
+				filepath,
+			),
+		},
 	}
 }
 
 // LoadError represents an error while loading another file
 type LoadError struct {
-	Message string
+	*exception
 }
 
 // Type returns EXCEPTION_OBJ
@@ -267,16 +294,18 @@ func (e *LoadError) Class() RubyClass { return loadErrorClass }
 // NewSyntaxError returns a new SyntaxError with the default message
 func NewSyntaxError(syntaxError string) *SyntaxError {
 	return &SyntaxError{
-		Message: fmt.Sprintf(
-			"syntax error, %s",
-			syntaxError,
-		),
+		&exception{
+			Message: fmt.Sprintf(
+				"syntax error, %s",
+				syntaxError,
+			),
+		},
 	}
 }
 
 // SyntaxError represents a syntax error in the ruby scripts
 type SyntaxError struct {
-	Message string
+	*exception
 }
 
 // Type returns EXCEPTION_OBJ
@@ -288,9 +317,14 @@ func (e *SyntaxError) Inspect() string { return formatException(e, e.Message) }
 // Class returns syntaxErrorClass
 func (e *SyntaxError) Class() RubyClass { return syntaxErrorClass }
 
+// NewNotImplementedError returns a NotImplementedError with the provided message
+func NewNotImplementedError(format string, args ...interface{}) *NotImplementedError {
+	return &NotImplementedError{&exception{Message: fmt.Sprintf(format, args...)}}
+}
+
 // NotImplementedError represents an error for a not implemented feature on a given platform
 type NotImplementedError struct {
-	Message string
+	*exception
 }
 
 // Type returns EXCEPTION_OBJ

--- a/object/integer.go
+++ b/object/integer.go
@@ -35,32 +35,32 @@ var integerMethods = map[string]RubyMethod{
 	"*":   withArity(1, publicMethod(integerMul)),
 }
 
-func integerDiv(context RubyObject, args ...RubyObject) RubyObject {
+func integerDiv(context RubyObject, args ...RubyObject) (RubyObject, error) {
 	i := context.(*Integer)
 	divisor, ok := args[0].(*Integer)
 	if !ok {
-		return NewCoercionTypeError(args[0], i)
+		return nil, NewCoercionTypeError(args[0], i)
 	}
 	if divisor.Value == 0 {
-		return NewZeroDivisionError()
+		return nil, NewZeroDivisionError()
 	}
-	return NewInteger(i.Value / divisor.Value)
+	return NewInteger(i.Value / divisor.Value), nil
 }
 
-func integerMul(context RubyObject, args ...RubyObject) RubyObject {
+func integerMul(context RubyObject, args ...RubyObject) (RubyObject, error) {
 	i := context.(*Integer)
 	factor, ok := args[0].(*Integer)
 	if !ok {
-		return NewCoercionTypeError(args[0], i)
+		return nil, NewCoercionTypeError(args[0], i)
 	}
-	return NewInteger(i.Value * factor.Value)
+	return NewInteger(i.Value * factor.Value), nil
 }
 
-func integerAdd(context RubyObject, args ...RubyObject) RubyObject {
+func integerAdd(context RubyObject, args ...RubyObject) (RubyObject, error) {
 	i := context.(*Integer)
 	add, ok := args[0].(*Integer)
 	if !ok {
-		return NewCoercionTypeError(args[0], i)
+		return nil, NewCoercionTypeError(args[0], i)
 	}
-	return NewInteger(i.Value + add.Value)
+	return NewInteger(i.Value + add.Value), nil
 }

--- a/object/integer_test.go
+++ b/object/integer_test.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -8,17 +9,21 @@ func TestIntegerDiv(t *testing.T) {
 	tests := []struct {
 		arguments []RubyObject
 		result    RubyObject
+		err       error
 	}{
 		{
 			[]RubyObject{NewInteger(2)},
 			NewInteger(2),
+			nil,
 		},
 		{
 			[]RubyObject{&String{""}},
+			nil,
 			NewCoercionTypeError(&String{}, &Integer{}),
 		},
 		{
 			[]RubyObject{NewInteger(0)},
+			nil,
 			NewZeroDivisionError(),
 		},
 	}
@@ -26,16 +31,11 @@ func TestIntegerDiv(t *testing.T) {
 	for _, testCase := range tests {
 		context := NewInteger(4)
 
-		result := integerDiv(context, testCase.arguments...)
+		result, err := integerDiv(context, testCase.arguments...)
 
-		if result.Inspect() != testCase.result.Inspect() {
-			t.Logf(
-				"Expected result to equal\n%s\n\tgot\n%s\n",
-				testCase.result.Inspect(),
-				result.Inspect(),
-			)
-			t.Fail()
-		}
+		checkError(t, err, testCase.err)
+
+		checkResult(t, result, testCase.result)
 	}
 }
 
@@ -43,13 +43,16 @@ func TestIntegerMul(t *testing.T) {
 	tests := []struct {
 		arguments []RubyObject
 		result    RubyObject
+		err       error
 	}{
 		{
 			[]RubyObject{NewInteger(2)},
 			NewInteger(8),
+			nil,
 		},
 		{
 			[]RubyObject{&String{""}},
+			nil,
 			NewCoercionTypeError(&String{}, &Integer{}),
 		},
 	}
@@ -57,16 +60,11 @@ func TestIntegerMul(t *testing.T) {
 	for _, testCase := range tests {
 		context := NewInteger(4)
 
-		result := integerMul(context, testCase.arguments...)
+		result, err := integerMul(context, testCase.arguments...)
 
-		if result.Inspect() != testCase.result.Inspect() {
-			t.Logf(
-				"Expected result to equal\n%s\n\tgot\n%s\n",
-				testCase.result.Inspect(),
-				result.Inspect(),
-			)
-			t.Fail()
-		}
+		checkError(t, err, testCase.err)
+
+		checkResult(t, result, testCase.result)
 	}
 }
 
@@ -74,13 +72,16 @@ func TestIntegerAdd(t *testing.T) {
 	tests := []struct {
 		arguments []RubyObject
 		result    RubyObject
+		err       error
 	}{
 		{
 			[]RubyObject{NewInteger(2)},
 			NewInteger(4),
+			nil,
 		},
 		{
 			[]RubyObject{&String{""}},
+			nil,
 			NewCoercionTypeError(&String{}, &Integer{}),
 		},
 	}
@@ -88,15 +89,31 @@ func TestIntegerAdd(t *testing.T) {
 	for _, testCase := range tests {
 		context := NewInteger(2)
 
-		result := integerAdd(context, testCase.arguments...)
+		result, err := integerAdd(context, testCase.arguments...)
 
-		if result.Inspect() != testCase.result.Inspect() {
-			t.Logf(
-				"Expected result to equal\n%s\n\tgot\n%s\n",
-				testCase.result.Inspect(),
-				result.Inspect(),
-			)
-			t.Fail()
-		}
+		checkError(t, err, testCase.err)
+
+		checkResult(t, result, testCase.result)
 	}
+}
+
+func checkError(t *testing.T, actual, expected error) {
+	if !reflect.DeepEqual(expected, actual) {
+		t.Logf("Expected error to equal %T:%v, got %T:%v\n", expected, expected, actual, actual)
+		t.Fail()
+	}
+}
+
+func checkResult(t *testing.T, actual, expected RubyObject) {
+	if !reflect.DeepEqual(expected, actual) {
+		t.Logf("Expected result to equal %s, got %s\n", toString(expected), toString(actual))
+		t.Fail()
+	}
+}
+
+func toString(obj RubyObject) string {
+	if obj == nil {
+		return "nil"
+	}
+	return obj.Inspect()
 }

--- a/object/kernel.go
+++ b/object/kernel.go
@@ -27,16 +27,16 @@ var kernelMethodSet = map[string]RubyMethod{
 	"puts":    privateMethod(kernelPuts),
 }
 
-func kernelPuts(context RubyObject, args ...RubyObject) RubyObject {
+func kernelPuts(context RubyObject, args ...RubyObject) (RubyObject, error) {
 	out := ""
 	for _, arg := range args {
 		out += arg.Inspect()
 	}
 	fmt.Println(out)
-	return NIL
+	return NIL, nil
 }
 
-func kernelMethods(context RubyObject, args ...RubyObject) RubyObject {
+func kernelMethods(context RubyObject, args ...RubyObject) (RubyObject, error) {
 	var methodSymbols []RubyObject
 	class := context.Class()
 	for class != nil {
@@ -49,18 +49,18 @@ func kernelMethods(context RubyObject, args ...RubyObject) RubyObject {
 		class = class.SuperClass()
 	}
 
-	return &Array{Elements: methodSymbols}
+	return &Array{Elements: methodSymbols}, nil
 }
 
-func kernelIsNil(context RubyObject, args ...RubyObject) RubyObject {
-	return FALSE
+func kernelIsNil(context RubyObject, args ...RubyObject) (RubyObject, error) {
+	return FALSE, nil
 }
 
-func kernelClass(context RubyObject, args ...RubyObject) RubyObject {
+func kernelClass(context RubyObject, args ...RubyObject) (RubyObject, error) {
 	class := context.Class()
 	if eigenClass, ok := class.(*eigenclass); ok {
 		class = eigenClass.Class()
 	}
 	classObj := class.(RubyClassObject)
-	return classObj
+	return classObj, nil
 }

--- a/object/kernel_test.go
+++ b/object/kernel_test.go
@@ -19,7 +19,9 @@ func TestKernelMethods(t *testing.T) {
 			},
 		}
 
-		result := kernelMethods(context)
+		result, err := kernelMethods(context)
+
+		checkError(t, err, nil)
 
 		array, ok := result.(*Array)
 		if !ok {
@@ -76,7 +78,9 @@ func TestKernelMethods(t *testing.T) {
 			},
 		}
 
-		result := kernelMethods(context)
+		result, err := kernelMethods(context)
+
+		checkError(t, err, nil)
 
 		array, ok := result.(*Array)
 		if !ok {
@@ -127,7 +131,9 @@ func TestKernelMethods(t *testing.T) {
 			},
 		}
 
-		result := kernelMethods(context)
+		result, err := kernelMethods(context)
+
+		checkError(t, err, nil)
 
 		array, ok := result.(*Array)
 		if !ok {
@@ -168,7 +174,9 @@ func TestKernelMethods(t *testing.T) {
 }
 
 func TestKernelIsNil(t *testing.T) {
-	result := kernelIsNil(TRUE)
+	result, err := kernelIsNil(TRUE)
+
+	checkError(t, err, nil)
 
 	boolean, ok := result.(*Boolean)
 	if !ok {
@@ -186,7 +194,9 @@ func TestKernelClass(t *testing.T) {
 	t.Run("regular object", func(t *testing.T) {
 		context := &Integer{1}
 
-		result := kernelClass(context)
+		result, err := kernelClass(context)
+
+		checkError(t, err, nil)
 
 		cl, ok := result.(*class)
 		if !ok {
@@ -204,7 +214,9 @@ func TestKernelClass(t *testing.T) {
 	t.Run("class object", func(t *testing.T) {
 		context := stringClass
 
-		result := kernelClass(context)
+		result, err := kernelClass(context)
+
+		checkError(t, err, nil)
 
 		cl, ok := result.(*class)
 		if !ok {
@@ -222,7 +234,9 @@ func TestKernelClass(t *testing.T) {
 	t.Run("class class", func(t *testing.T) {
 		context := classClass
 
-		result := kernelClass(context)
+		result, err := kernelClass(context)
+
+		checkError(t, err, nil)
 
 		cl, ok := result.(*class)
 		if !ok {

--- a/object/method_set.go
+++ b/object/method_set.go
@@ -18,15 +18,15 @@ const (
 
 // RubyMethod defines a Ruby method
 type RubyMethod interface {
-	Call(context RubyObject, args ...RubyObject) RubyObject
+	Call(context RubyObject, args ...RubyObject) (RubyObject, error)
 	Visibility() MethodVisibility
 }
 
 func withArity(arity int, fn RubyMethod) RubyMethod {
 	return &method{
-		fn: func(context RubyObject, args ...RubyObject) RubyObject {
+		fn: func(context RubyObject, args ...RubyObject) (RubyObject, error) {
 			if len(args) != arity {
-				return NewWrongNumberOfArgumentsError(arity, len(args))
+				return nil, NewWrongNumberOfArgumentsError(arity, len(args))
 			}
 			return fn.Call(context, args...)
 		},
@@ -34,15 +34,15 @@ func withArity(arity int, fn RubyMethod) RubyMethod {
 	}
 }
 
-func publicMethod(fn func(context RubyObject, args ...RubyObject) RubyObject) RubyMethod {
+func publicMethod(fn func(context RubyObject, args ...RubyObject) (RubyObject, error)) RubyMethod {
 	return &method{visibility: PUBLIC_METHOD, fn: fn}
 }
 
-func protectedMethod(fn func(context RubyObject, args ...RubyObject) RubyObject) RubyMethod {
+func protectedMethod(fn func(context RubyObject, args ...RubyObject) (RubyObject, error)) RubyMethod {
 	return &method{visibility: PROTECTED_METHOD, fn: fn}
 }
 
-func privateMethod(fn func(context RubyObject, args ...RubyObject) RubyObject) RubyMethod {
+func privateMethod(fn func(context RubyObject, args ...RubyObject) (RubyObject, error)) RubyMethod {
 	return &method{visibility: PRIVATE_METHOD, fn: fn}
 }
 
@@ -55,10 +55,10 @@ func (m publicMethodX) Visibility() MethodVisibility { return PUBLIC_METHOD }
 
 type method struct {
 	visibility MethodVisibility
-	fn         func(context RubyObject, args ...RubyObject) RubyObject
+	fn         func(context RubyObject, args ...RubyObject) (RubyObject, error)
 }
 
-func (m *method) Call(context RubyObject, args ...RubyObject) RubyObject {
+func (m *method) Call(context RubyObject, args ...RubyObject) (RubyObject, error) {
 	return m.fn(context, args...)
 }
 func (m *method) Visibility() MethodVisibility { return m.visibility }

--- a/object/module.go
+++ b/object/module.go
@@ -35,7 +35,7 @@ var moduleMethods = map[string]RubyMethod{
 	"ancestors": withArity(0, publicMethod(moduleAncestors)),
 }
 
-func moduleAncestors(context RubyObject, args ...RubyObject) RubyObject {
+func moduleAncestors(context RubyObject, args ...RubyObject) (RubyObject, error) {
 	class := context.(RubyClassObject)
 	var ancestors []RubyObject
 	ancestors = append(ancestors, &String{class.Inspect()})
@@ -47,13 +47,16 @@ func moduleAncestors(context RubyObject, args ...RubyObject) RubyObject {
 	}
 	superClass := class.SuperClass()
 	if superClass != nil {
-		superAncestors := moduleAncestors(superClass.(RubyObject))
+		superAncestors, err := moduleAncestors(superClass.(RubyObject))
+		if err != nil {
+			return nil, err
+		}
 		ancestors = append(ancestors, superAncestors.(*Array).Elements...)
 	}
-	return &Array{ancestors}
+	return &Array{ancestors}, nil
 }
 
-func moduleIncludedModules(context RubyObject, args ...RubyObject) RubyObject {
+func moduleIncludedModules(context RubyObject, args ...RubyObject) (RubyObject, error) {
 	class := context.(RubyClassObject)
 	var includedModules []RubyObject
 
@@ -65,9 +68,12 @@ func moduleIncludedModules(context RubyObject, args ...RubyObject) RubyObject {
 
 	superClass := class.SuperClass()
 	if superClass != nil {
-		superIncludedModules := moduleIncludedModules(superClass.(RubyObject))
+		superIncludedModules, err := moduleIncludedModules(superClass.(RubyObject))
+		if err != nil {
+			return nil, err
+		}
 		includedModules = append(includedModules, superIncludedModules.(*Array).Elements...)
 	}
 
-	return &Array{includedModules}
+	return &Array{includedModules}, nil
 }

--- a/object/module_test.go
+++ b/object/module_test.go
@@ -10,7 +10,9 @@ func TestModuleAncestors(t *testing.T) {
 	t.Run("class extending from BasicObject", func(t *testing.T) {
 		context := &class{name: "BasicObjectAsParent", superClass: basicObjectClass}
 
-		result := moduleAncestors(context)
+		result, err := moduleAncestors(context)
+
+		checkError(t, err, nil)
 
 		array, ok := result.(*Array)
 		if !ok {
@@ -37,7 +39,9 @@ func TestModuleAncestors(t *testing.T) {
 			kernelModule,
 		)
 
-		result := moduleAncestors(context)
+		result, err := moduleAncestors(context)
+
+		checkError(t, err, nil)
 
 		array, ok := result.(*Array)
 		if !ok {
@@ -77,7 +81,9 @@ func TestModuleAncestors(t *testing.T) {
 
 		for _, testCase := range tests {
 			t.Run(testCase.class.Inspect(), func(t *testing.T) {
-				result := moduleAncestors(testCase.class)
+				result, err := moduleAncestors(testCase.class)
+
+				checkError(t, err, nil)
 
 				array, ok := result.(*Array)
 				if !ok {
@@ -111,7 +117,9 @@ func TestModuleIncludedModules(t *testing.T) {
 		superClass: mixin(basicObjectClass, kernelModule),
 	}
 
-	result := moduleIncludedModules(context)
+	result, err := moduleIncludedModules(context)
+
+	checkError(t, err, nil)
 
 	array, ok := result.(*Array)
 	if !ok {

--- a/object/nil.go
+++ b/object/nil.go
@@ -22,6 +22,6 @@ var nilMethods = map[string]RubyMethod{
 	"nil?": withArity(0, publicMethod(nilIsNil)),
 }
 
-func nilIsNil(context RubyObject, args ...RubyObject) RubyObject {
-	return TRUE
+func nilIsNil(context RubyObject, args ...RubyObject) (RubyObject, error) {
+	return TRUE, nil
 }

--- a/object/nil_test.go
+++ b/object/nil_test.go
@@ -3,7 +3,9 @@ package object
 import "testing"
 
 func TestNilIsNil(t *testing.T) {
-	result := nilIsNil(NIL)
+	result, err := nilIsNil(NIL)
+
+	checkError(t, err, nil)
 
 	boolean, ok := result.(*Boolean)
 	if !ok {

--- a/object/ruby_object.go
+++ b/object/ruby_object.go
@@ -104,7 +104,7 @@ type Function struct {
 	Parameters       []*ast.Identifier
 	Body             *ast.BlockStatement
 	Env              Environment
-	CallFn           func(context RubyObject, args []RubyObject) RubyObject
+	CallFn           func(context RubyObject, args []RubyObject) (RubyObject, error)
 	MethodVisibility MethodVisibility
 }
 
@@ -131,7 +131,7 @@ func (f *Function) Inspect() string {
 func (f *Function) Class() RubyClass { return nil }
 
 // Call implements the RubyMethod interface. It calls f.CallFn
-func (f *Function) Call(context RubyObject, args ...RubyObject) RubyObject {
+func (f *Function) Call(context RubyObject, args ...RubyObject) (RubyObject, error) {
 	return f.CallFn(f, args)
 }
 

--- a/object/send.go
+++ b/object/send.go
@@ -1,7 +1,7 @@
 package object
 
 // Send sends message method with args to context and returns its result
-func Send(context RubyObject, method string, args ...RubyObject) RubyObject {
+func Send(context RubyObject, method string, args ...RubyObject) (RubyObject, error) {
 	class := context.Class()
 
 	// search for the method in the ancestry tree
@@ -13,7 +13,7 @@ func Send(context RubyObject, method string, args ...RubyObject) RubyObject {
 		}
 
 		if fn.Visibility() == PRIVATE_METHOD && context.Type() != SELF {
-			return NewPrivateNoMethodError(context, method)
+			return nil, NewPrivateNoMethodError(context, method)
 		}
 
 		return fn.Call(context, args...)
@@ -49,7 +49,7 @@ func AddMethod(context RubyObject, methodName string, method *Function) RubyObje
 	return extended
 }
 
-func methodMissing(context RubyObject, args ...RubyObject) RubyObject {
+func methodMissing(context RubyObject, args ...RubyObject) (RubyObject, error) {
 	class := context.Class()
 
 	// search for method_missing in the ancestry tree
@@ -61,5 +61,5 @@ func methodMissing(context RubyObject, args ...RubyObject) RubyObject {
 		}
 		return fn.Call(context, args...)
 	}
-	return NewNoMethodError(context, args[0].(*Symbol).Value)
+	return nil, NewNoMethodError(context, args[0].(*Symbol).Value)
 }

--- a/object/send_test.go
+++ b/object/send_test.go
@@ -22,22 +22,22 @@ func (t *testRubyObject) Class() RubyClass {
 
 func TestSend(t *testing.T) {
 	superMethods := map[string]RubyMethod{
-		"a_super_method": publicMethod(func(context RubyObject, args ...RubyObject) RubyObject {
-			return TRUE
+		"a_super_method": publicMethod(func(context RubyObject, args ...RubyObject) (RubyObject, error) {
+			return TRUE, nil
 		}),
-		"a_private_super_method": privateMethod(func(context RubyObject, args ...RubyObject) RubyObject {
-			return FALSE
+		"a_private_super_method": privateMethod(func(context RubyObject, args ...RubyObject) (RubyObject, error) {
+			return FALSE, nil
 		}),
 	}
 	methods := map[string]RubyMethod{
-		"a_method": publicMethod(func(context RubyObject, args ...RubyObject) RubyObject {
-			return TRUE
+		"a_method": publicMethod(func(context RubyObject, args ...RubyObject) (RubyObject, error) {
+			return TRUE, nil
 		}),
-		"another_method": publicMethod(func(context RubyObject, args ...RubyObject) RubyObject {
-			return FALSE
+		"another_method": publicMethod(func(context RubyObject, args ...RubyObject) (RubyObject, error) {
+			return FALSE, nil
 		}),
-		"a_private_method": privateMethod(func(context RubyObject, args ...RubyObject) RubyObject {
-			return FALSE
+		"a_private_method": privateMethod(func(context RubyObject, args ...RubyObject) (RubyObject, error) {
+			return FALSE, nil
 		}),
 	}
 	t.Run("normal object as context", func(t *testing.T) {
@@ -56,40 +56,46 @@ func TestSend(t *testing.T) {
 		tests := []struct {
 			method         string
 			expectedResult RubyObject
+			expectedError  error
 		}{
 			{
 				"a_method",
 				TRUE,
+				nil,
 			},
 			{
 				"another_method",
 				FALSE,
+				nil,
 			},
 			{
 				"a_super_method",
 				TRUE,
+				nil,
 			},
 			{
 				"a_private_method",
+				nil,
 				NewPrivateNoMethodError(context, "a_private_method"),
 			},
 			{
 				"a_private_super_method",
+				nil,
 				NewPrivateNoMethodError(context, "a_private_super_method"),
 			},
 			{
 				"unknown_method",
+				nil,
 				NewNoMethodError(context, "unknown_method"),
 			},
 		}
 
 		for _, testCase := range tests {
-			result := Send(context, testCase.method)
+			result, err := Send(context, testCase.method)
 
-			if !reflect.DeepEqual(result, testCase.expectedResult) {
-				t.Logf("Expected result to equal\n%+#v\n\tgot\n%+#v\n", testCase.expectedResult, result)
-				t.Fail()
-			}
+			checkError(t, err, testCase.expectedError)
+
+			checkResult(t, result, testCase.expectedResult)
 		}
 	})
 	t.Run("self as context", func(t *testing.T) {
@@ -110,35 +116,47 @@ func TestSend(t *testing.T) {
 		tests := []struct {
 			method         string
 			expectedResult RubyObject
+			expectedError  error
 		}{
 			{
 				"a_method",
 				TRUE,
+				nil,
 			},
 			{
 				"another_method",
 				FALSE,
+				nil,
 			},
 			{
 				"a_super_method",
 				TRUE,
+				nil,
 			},
 			{
 				"a_private_method",
 				FALSE,
+				nil,
 			},
 			{
 				"a_private_super_method",
 				FALSE,
+				nil,
 			},
 			{
 				"unknown_method",
+				nil,
 				NewNoMethodError(context, "unknown_method"),
 			},
 		}
 
 		for _, testCase := range tests {
-			result := Send(context, testCase.method)
+			result, err := Send(context, testCase.method)
+
+			if !reflect.DeepEqual(err, testCase.expectedError) {
+				t.Logf("Expected err to equal\n%+#v\n\tgot\n%+#v\n", testCase.expectedError, err)
+				t.Fail()
+			}
 
 			if !reflect.DeepEqual(result, testCase.expectedResult) {
 				t.Logf("Expected result to equal\n%+#v\n\tgot\n%+#v\n", testCase.expectedResult, result)
@@ -184,8 +202,8 @@ func TestAddMethod(t *testing.T) {
 				},
 			},
 			class: newEigenclass(objectClass, map[string]RubyMethod{
-				"bar": publicMethod(func(context RubyObject, args ...RubyObject) RubyObject {
-					return NIL
+				"bar": publicMethod(func(context RubyObject, args ...RubyObject) (RubyObject, error) {
+					return NIL, nil
 				}),
 			}),
 		}
@@ -264,8 +282,8 @@ func TestAddMethod(t *testing.T) {
 					},
 				},
 				class: newEigenclass(objectClass, map[string]RubyMethod{
-					"bar": publicMethod(func(context RubyObject, args ...RubyObject) RubyObject {
-						return NIL
+					"bar": publicMethod(func(context RubyObject, args ...RubyObject) (RubyObject, error) {
+						return NIL, nil
 					}),
 				}),
 			},

--- a/object/string.go
+++ b/object/string.go
@@ -21,18 +21,18 @@ func (s *String) Type() Type { return STRING_OBJ }
 func (s *String) Class() RubyClass { return stringClass }
 
 var stringClassMethods = map[string]RubyMethod{
-	"new": publicMethod(func(context RubyObject, args ...RubyObject) RubyObject {
+	"new": publicMethod(func(context RubyObject, args ...RubyObject) (RubyObject, error) {
 		switch len(args) {
 		case 0:
-			return &String{}
+			return &String{}, nil
 		case 1:
 			str, ok := args[0].(*String)
 			if !ok {
-				return NewImplicitConversionTypeError(args[0], context)
+				return nil, NewImplicitConversionTypeError(args[0], context)
 			}
-			return &String{Value: str.Value}
+			return &String{Value: str.Value}, nil
 		default:
-			return NewWrongNumberOfArgumentsError(len(args), 1)
+			return nil, NewWrongNumberOfArgumentsError(len(args), 1)
 		}
 	}),
 }
@@ -41,7 +41,7 @@ var stringMethods = map[string]RubyMethod{
 	"to_s": withArity(0, publicMethod(stringToS)),
 }
 
-func stringToS(context RubyObject, args ...RubyObject) RubyObject {
+func stringToS(context RubyObject, args ...RubyObject) (RubyObject, error) {
 	str := context.(*String)
-	return &String{str.Value}
+	return &String{str.Value}, nil
 }


### PR DESCRIPTION
Return errors instead of only RubyObjects which wrap an error.