### PR TITLE
Encapsule methodSets into interface

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -307,7 +307,7 @@ func TestModuleObject(t *testing.T) {
 
 		actualMethods := make(map[string]string)
 
-		methods := module.Class().Methods()
+		methods := module.Class().Methods().GetAll()
 		for name, method := range methods {
 			if function, ok := method.(*object.Function); ok {
 				actualMethods[name] = function.Inspect()
@@ -365,7 +365,7 @@ func TestFunctionObject(t *testing.T) {
 		}
 
 		self, _ := env.Get("self")
-		method, ok := self.Class().Methods()["foo"]
+		method, ok := self.Class().Methods().Get("foo")
 		if !ok {
 			t.Logf("Expected function to be added to self")
 			t.Fail()

--- a/object/basic_object.go
+++ b/object/basic_object.go
@@ -1,5 +1,7 @@
 package object
 
+import "fmt"
+
 var basicObjectClass RubyClassObject = newClass("BasicObject", nil, basicObjectMethods, basicObjectClassMethods)
 
 func init() {
@@ -10,7 +12,10 @@ func init() {
 type basicObject struct{}
 
 // Inspect returns empty string. BasicObjects do not have an `inspect` method.
-func (b *basicObject) Inspect() string { return "" }
+func (b *basicObject) Inspect() string {
+	fmt.Println("(Object doesn't support #inspect)")
+	return ""
+}
 
 // Type returns the ObjectType of the array
 func (b *basicObject) Type() Type { return BASIC_OBJECT_OBJ }

--- a/object/call_context.go
+++ b/object/call_context.go
@@ -1,0 +1,40 @@
+package object
+
+import (
+	"fmt"
+
+	"github.com/goruby/goruby/ast"
+)
+
+// CallContext represents the context information when sending a message to an
+// object.
+type CallContext interface {
+	// Env returns the current environment at call time
+	Env() Environment
+	// Eval represents an evalualtion method suitable to eval arbitrary Ruby
+	// AST Nodes and transform them into a resulting Ruby object or an error.
+	Eval(ast.Node, Environment) (RubyObject, error)
+	// Receiver returns the Ruby object the message is sent to
+	Receiver() RubyObject
+}
+
+// NewCallContext returns a new CallContext with a stubbed eval function
+func NewCallContext(env Environment, receiver RubyObject) CallContext {
+	return &callContext{
+		env:      env,
+		eval:     func(node ast.Node, env Environment) (RubyObject, error) { return nil, fmt.Errorf("No eval present") },
+		receiver: receiver,
+	}
+}
+
+type callContext struct {
+	env      Environment
+	eval     func(node ast.Node, env Environment) (RubyObject, error)
+	receiver RubyObject
+}
+
+func (c *callContext) Env() Environment { return c.env }
+func (c *callContext) Eval(node ast.Node, env Environment) (RubyObject, error) {
+	return c.eval(node, env)
+}
+func (c *callContext) Receiver() RubyObject { return c.receiver }

--- a/object/class.go
+++ b/object/class.go
@@ -2,7 +2,7 @@ package object
 
 import "fmt"
 
-var classClass RubyClassObject = &class{name: "Class", superClass: moduleClass, instanceMethods: classMethods}
+var classClass RubyClassObject = &class{name: "Class", superClass: moduleClass, instanceMethods: NewMethodSet(classMethods)}
 
 func init() {
 	classClass.(*class).class = classClass
@@ -11,7 +11,7 @@ func init() {
 
 // newClass returns a new Ruby Class
 func newClass(name string, superClass RubyClass, instanceMethods, classMethods map[string]RubyMethod) *class {
-	return &class{name: name, superClass: superClass, instanceMethods: instanceMethods, class: newEigenclass(classClass, classMethods)}
+	return &class{name: name, superClass: superClass, instanceMethods: NewMethodSet(instanceMethods), class: newEigenclass(classClass, classMethods)}
 }
 
 // class represents a Ruby Class object
@@ -19,7 +19,7 @@ type class struct {
 	name            string
 	superClass      RubyClass
 	class           RubyClass
-	instanceMethods map[string]RubyMethod
+	instanceMethods SettableMethodSet
 }
 
 func (c *class) Inspect() string {
@@ -38,7 +38,7 @@ func (c *class) Class() RubyClass {
 func (c *class) SuperClass() RubyClass {
 	return c.superClass
 }
-func (c *class) Methods() map[string]RubyMethod {
+func (c *class) Methods() MethodSet {
 	return c.instanceMethods
 }
 
@@ -54,7 +54,7 @@ func classSuperclass(context CallContext, args ...RubyObject) (RubyObject, error
 	if superclass == nil {
 		return NIL, nil
 	}
-	if mixin, ok := superclass.(*methodSet); ok {
+	if mixin, ok := superclass.(*mixin); ok {
 		return mixin.RubyClassObject, nil
 	}
 	return superclass.(RubyObject), nil

--- a/object/class_test.go
+++ b/object/class_test.go
@@ -66,11 +66,11 @@ func TestClassMethods(t *testing.T) {
 		"a_method": nil,
 	}
 
-	context := &class{instanceMethods: contextMethods}
+	context := &class{instanceMethods: NewMethodSet(contextMethods)}
 
 	actual := context.Methods()
 
-	expected := contextMethods
+	expected := NewMethodSet(contextMethods)
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Logf("Expected Methods to equal %v, got %v", expected, actual)

--- a/object/eigenclass.go
+++ b/object/eigenclass.go
@@ -1,12 +1,12 @@
 package object
 
-func newEigenclass(wrappedClass RubyClassObject, methods map[string]RubyMethod) *eigenclass {
-	return &eigenclass{methods: methods, wrappedClass: wrappedClass}
+func newEigenclass(wrappedClass RubyClass, methods map[string]RubyMethod) *eigenclass {
+	return &eigenclass{methods: NewMethodSet(methods), wrappedClass: wrappedClass}
 }
 
 type eigenclass struct {
-	methods      map[string]RubyMethod
-	wrappedClass RubyClassObject
+	methods      SettableMethodSet
+	wrappedClass RubyClass
 }
 
 func (e *eigenclass) Inspect() string {
@@ -22,7 +22,7 @@ func (e *eigenclass) Class() RubyClass {
 	}
 	return classClass
 }
-func (e *eigenclass) Methods() map[string]RubyMethod { return e.methods }
+func (e *eigenclass) Methods() MethodSet { return e.methods }
 func (e *eigenclass) SuperClass() RubyClass {
 	if e.wrappedClass != nil {
 		return e.wrappedClass
@@ -30,5 +30,5 @@ func (e *eigenclass) SuperClass() RubyClass {
 	return objectClass
 }
 func (e *eigenclass) addMethod(name string, method RubyMethod) {
-	e.methods[name] = method
+	e.methods.Set(name, method)
 }

--- a/object/kernel.go
+++ b/object/kernel.go
@@ -39,7 +39,7 @@ func kernelMethods(context CallContext, args ...RubyObject) (RubyObject, error) 
 	var methodSymbols []RubyObject
 	class := context.Receiver().Class()
 	for class != nil {
-		methods := class.Methods()
+		methods := class.Methods().GetAll()
 		for meth, fn := range methods {
 			if fn.Visibility() == PUBLIC_METHOD {
 				methodSymbols = append(methodSymbols, &Symbol{meth})
@@ -130,7 +130,7 @@ func kernelExtend(context CallContext, args ...RubyObject) (RubyObject, error) {
 	extended := &extendedObject{
 		RubyObject: context.Receiver(),
 		class: newEigenclass(
-			mixin(context.Receiver().Class().(RubyClassObject), modules...),
+			newMixin(context.Receiver().Class().(RubyClassObject), modules...),
 			map[string]RubyMethod{},
 		),
 	}

--- a/object/kernel_test.go
+++ b/object/kernel_test.go
@@ -18,7 +18,7 @@ func TestKernelMethods(t *testing.T) {
 		context := &callContext{
 			receiver: &testRubyObject{
 				class: &class{
-					instanceMethods: contextMethods,
+					instanceMethods: NewMethodSet(contextMethods),
 					superClass:      nil,
 				},
 			},
@@ -76,9 +76,9 @@ func TestKernelMethods(t *testing.T) {
 		context := &callContext{
 			receiver: &testRubyObject{
 				class: &class{
-					instanceMethods: contextMethods,
+					instanceMethods: NewMethodSet(contextMethods),
 					superClass: &class{
-						instanceMethods: superClassMethods,
+						instanceMethods: NewMethodSet(superClassMethods),
 						superClass:      nil,
 					},
 				},
@@ -134,7 +134,7 @@ func TestKernelMethods(t *testing.T) {
 		context := &callContext{
 			receiver: &testRubyObject{
 				class: &class{
-					instanceMethods: contextMethods,
+					instanceMethods: NewMethodSet(contextMethods),
 					superClass:      nil,
 				},
 			},
@@ -703,8 +703,8 @@ func TestKernelExtend(t *testing.T) {
 	}
 
 	expectedClass := &eigenclass{
-		map[string]RubyMethod{},
-		&methodSet{
+		&methodSet{map[string]RubyMethod{}},
+		&mixin{
 			objectToExtend.Class().(RubyClassObject),
 			[]*Module{module},
 		},

--- a/object/mixin.go
+++ b/object/mixin.go
@@ -1,0 +1,24 @@
+package object
+
+func newMixin(class RubyClassObject, modules ...*Module) *mixin {
+	return &mixin{class, modules}
+}
+
+type mixin struct {
+	RubyClassObject
+	modules []*Module
+}
+
+func (m *mixin) Methods() MethodSet {
+	var methods = make(map[string]RubyMethod)
+	for _, mod := range m.modules {
+		moduleMethods := mod.Class().Methods()
+		for k, v := range moduleMethods.GetAll() {
+			methods[k] = v
+		}
+	}
+	for k, v := range m.RubyClassObject.Methods().GetAll() {
+		methods[k] = v
+	}
+	return NewMethodSet(methods)
+}

--- a/object/module.go
+++ b/object/module.go
@@ -1,6 +1,6 @@
 package object
 
-var moduleClass RubyClassObject = &class{name: "Module", instanceMethods: moduleMethods}
+var moduleClass RubyClassObject = &class{name: "Module", instanceMethods: NewMethodSet(moduleMethods)}
 
 func init() {
 	moduleClass.(*class).superClass = objectClass
@@ -51,7 +51,7 @@ func moduleAncestors(context CallContext, args ...RubyObject) (RubyObject, error
 	var ancestors []RubyObject
 	ancestors = append(ancestors, &String{class.Inspect()})
 
-	if mixin, ok := class.(*methodSet); ok {
+	if mixin, ok := class.(*mixin); ok {
 		for _, m := range mixin.modules {
 			ancestors = append(ancestors, &String{m.name})
 		}
@@ -72,7 +72,7 @@ func moduleIncludedModules(context CallContext, args ...RubyObject) (RubyObject,
 	class := context.Receiver().(RubyClassObject)
 	var includedModules []RubyObject
 
-	if mixin, ok := class.(*methodSet); ok {
+	if mixin, ok := class.(*mixin); ok {
 		for _, m := range mixin.modules {
 			includedModules = append(includedModules, &String{m.name})
 		}

--- a/object/module_test.go
+++ b/object/module_test.go
@@ -37,7 +37,7 @@ func TestModuleAncestors(t *testing.T) {
 	})
 	t.Run("class with mixed in modules", func(t *testing.T) {
 		context := &callContext{
-			receiver: mixin(
+			receiver: newMixin(
 				&class{name: "BasicObjectAsParent", superClass: basicObjectClass},
 				kernelModule,
 			),
@@ -120,7 +120,7 @@ func TestModuleAncestors(t *testing.T) {
 func TestModuleIncludedModules(t *testing.T) {
 	context := &callContext{
 		receiver: &class{
-			superClass: mixin(basicObjectClass, kernelModule),
+			superClass: newMixin(basicObjectClass, kernelModule),
 		},
 	}
 

--- a/object/object.go
+++ b/object/object.go
@@ -1,6 +1,6 @@
 package object
 
-var objectClass = mixin(newClass("Object", basicObjectClass, objectMethods, objectClassMethods), kernelModule)
+var objectClass = newMixin(newClass("Object", basicObjectClass, objectMethods, objectClassMethods), kernelModule)
 
 func init() {
 	classes.Set("Object", objectClass)

--- a/object/ruby_object.go
+++ b/object/ruby_object.go
@@ -11,31 +11,22 @@ import (
 type Type string
 
 const (
-	EIGENCLASS_OBJ         Type = "EIGENCLASS"
-	FUNCTION_OBJ           Type = "FUNCTION"
-	RETURN_VALUE_OBJ       Type = "RETURN_VALUE"
-	BASIC_OBJECT_OBJ       Type = "BASIC_OBJECT"
-	BASIC_OBJECT_CLASS_OBJ Type = "BASIC_OBJECT_CLASS"
-	OBJECT_OBJ             Type = "OBJECT"
-	OBJECT_CLASS_OBJ       Type = "OBJECT_CLASS"
-	CLASS_OBJ              Type = "CLASS"
-	CLASS_CLASS_OBJ        Type = "CLASS_CLASS"
-	ARRAY_OBJ              Type = "ARRAY"
-	ARRAY_CLASS_OBJ        Type = "ARRAY_CLASS"
-	INTEGER_OBJ            Type = "INTEGER"
-	INTEGER_CLASS_OBJ      Type = "INTEGER_CLASS"
-	STRING_OBJ             Type = "STRING"
-	STRING_CLASS_OBJ       Type = "STRING_CLASS"
-	SYMBOL_OBJ             Type = "SYMBOL"
-	BOOLEAN_OBJ            Type = "BOOLEAN"
-	BOOLEAN_CLASS_OBJ      Type = "BOOLEAN_CLASS"
-	NIL_OBJ                Type = "NIL"
-	NIL_CLASS_OBJ          Type = "NIL_CLASS"
-	EXCEPTION_OBJ          Type = "EXCEPTION"
-	EXCEPTION_CLASS_OBJ    Type = "EXCEPTION_CLASS"
-	MODULE_OBJ             Type = "MODULE"
-	MODULE_CLASS_OBJ       Type = "MODULE_CLASS"
-	SELF                   Type = "SELF"
+	EIGENCLASS_OBJ   Type = "EIGENCLASS"
+	FUNCTION_OBJ     Type = "FUNCTION"
+	RETURN_VALUE_OBJ Type = "RETURN_VALUE"
+	BASIC_OBJECT_OBJ Type = "BASIC_OBJECT"
+	OBJECT_OBJ       Type = "OBJECT"
+	CLASS_OBJ        Type = "CLASS"
+	ARRAY_OBJ        Type = "ARRAY"
+	INTEGER_OBJ      Type = "INTEGER"
+	STRING_OBJ       Type = "STRING"
+	SYMBOL_OBJ       Type = "SYMBOL"
+	BOOLEAN_OBJ      Type = "BOOLEAN"
+	NIL_OBJ          Type = "NIL"
+	NIL_CLASS_OBJ    Type = "NIL_CLASS"
+	EXCEPTION_OBJ    Type = "EXCEPTION"
+	MODULE_OBJ       Type = "MODULE"
+	SELF             Type = "SELF"
 )
 
 type inspectable interface {
@@ -51,7 +42,7 @@ type RubyObject interface {
 
 // RubyClass represents a class in Ruby
 type RubyClass interface {
-	Methods() map[string]RubyMethod
+	Methods() MethodSet
 	SuperClass() RubyClass
 }
 

--- a/object/send.go
+++ b/object/send.go
@@ -1,44 +1,5 @@
 package object
 
-import (
-	"fmt"
-
-	"github.com/goruby/goruby/ast"
-)
-
-// CallContext represents the context information when sending a message to an
-// object.
-type CallContext interface {
-	// Env returns the current environment at call time
-	Env() Environment
-	// Eval represents an evalualtion method suitable to eval arbitrary Ruby
-	// AST Nodes and transform them into a resulting Ruby object or an error.
-	Eval(ast.Node, Environment) (RubyObject, error)
-	// Receiver returns the Ruby object the message is sent to
-	Receiver() RubyObject
-}
-
-// NewCallContext returns a new CallContext with a stubbed eval function
-func NewCallContext(env Environment, receiver RubyObject) CallContext {
-	return &callContext{
-		env:      env,
-		eval:     func(node ast.Node, env Environment) (RubyObject, error) { return nil, fmt.Errorf("No eval present") },
-		receiver: receiver,
-	}
-}
-
-type callContext struct {
-	env      Environment
-	eval     func(node ast.Node, env Environment) (RubyObject, error)
-	receiver RubyObject
-}
-
-func (c *callContext) Env() Environment { return c.env }
-func (c *callContext) Eval(node ast.Node, env Environment) (RubyObject, error) {
-	return c.eval(node, env)
-}
-func (c *callContext) Receiver() RubyObject { return c.receiver }
-
 // Send sends message method with args to context and returns its result
 func Send(context CallContext, method string, args ...RubyObject) (RubyObject, error) {
 	receiver := context.Receiver()
@@ -46,7 +7,7 @@ func Send(context CallContext, method string, args ...RubyObject) (RubyObject, e
 
 	// search for the method in the ancestry tree
 	for class != nil {
-		fn, ok := class.Methods()[method]
+		fn, ok := class.Methods().Get(method)
 		if !ok {
 			class = class.SuperClass()
 			continue
@@ -94,7 +55,7 @@ func methodMissing(context CallContext, args ...RubyObject) (RubyObject, error) 
 
 	// search for method_missing in the ancestry tree
 	for class != nil {
-		fn, ok := class.Methods()["method_missing"]
+		fn, ok := class.Methods().Get("method_missing")
 		if !ok {
 			class = class.SuperClass()
 			continue

--- a/object/send_test.go
+++ b/object/send_test.go
@@ -46,10 +46,10 @@ func TestSend(t *testing.T) {
 			receiver: &testRubyObject{
 				class: &class{
 					name:            "base class",
-					instanceMethods: methods,
+					instanceMethods: NewMethodSet(methods),
 					superClass: &class{
 						name:            "super class",
-						instanceMethods: superMethods,
+						instanceMethods: NewMethodSet(superMethods),
 						superClass:      basicObjectClass,
 					},
 				},
@@ -107,10 +107,10 @@ func TestSend(t *testing.T) {
 				&testRubyObject{
 					class: &class{
 						name:            "base class",
-						instanceMethods: methods,
+						instanceMethods: NewMethodSet(methods),
 						superClass: &class{
 							name:            "super class",
-							instanceMethods: superMethods,
+							instanceMethods: NewMethodSet(superMethods),
 							superClass:      basicObjectClass,
 						},
 					},
@@ -177,7 +177,7 @@ func TestAddMethod(t *testing.T) {
 		context := &testRubyObject{
 			class: &class{
 				name:            "base class",
-				instanceMethods: map[string]RubyMethod{},
+				instanceMethods: NewMethodSet(map[string]RubyMethod{}),
 				superClass:      objectClass,
 			},
 		}
@@ -192,7 +192,7 @@ func TestAddMethod(t *testing.T) {
 
 		newContext := AddMethod(context, "foo", fn)
 
-		_, ok := newContext.Class().Methods()["foo"]
+		_, ok := newContext.Class().Methods().Get("foo")
 		if !ok {
 			t.Logf("Expected object to have method foo")
 			t.Fail()
@@ -220,7 +220,7 @@ func TestAddMethod(t *testing.T) {
 			t.Fail()
 		}
 
-		_, ok = module.Class().Methods()["foo"]
+		_, ok = module.Class().Methods().Get("foo")
 		if !ok {
 			t.Logf("Expected object to have method foo")
 			t.Fail()
@@ -231,7 +231,7 @@ func TestAddMethod(t *testing.T) {
 			RubyObject: &testRubyObject{
 				class: &class{
 					name:            "base class",
-					instanceMethods: map[string]RubyMethod{},
+					instanceMethods: NewMethodSet(map[string]RubyMethod{}),
 					superClass:      objectClass,
 				},
 			},
@@ -252,13 +252,13 @@ func TestAddMethod(t *testing.T) {
 
 		newContext := AddMethod(context, "foo", fn)
 
-		_, ok := newContext.Class().Methods()["foo"]
+		_, ok := newContext.Class().Methods().Get("foo")
 		if !ok {
 			t.Logf("Expected object to have method foo")
 			t.Fail()
 		}
 
-		_, ok = newContext.Class().Methods()["bar"]
+		_, ok = newContext.Class().Methods().Get("bar")
 		if !ok {
 			t.Logf("Expected object to have method bar")
 			t.Fail()
@@ -268,7 +268,7 @@ func TestAddMethod(t *testing.T) {
 		vanillaObject := &testRubyObject{
 			class: &class{
 				name:            "base class",
-				instanceMethods: map[string]RubyMethod{},
+				instanceMethods: NewMethodSet(map[string]RubyMethod{}),
 				superClass:      objectClass,
 			},
 			Name: "main",
@@ -287,7 +287,7 @@ func TestAddMethod(t *testing.T) {
 
 		newContext := AddMethod(context, "foo", fn)
 
-		_, ok := newContext.Class().Methods()["foo"]
+		_, ok := newContext.Class().Methods().Get("foo")
 		if !ok {
 			t.Logf("Expected object to have method foo")
 			t.Fail()
@@ -324,7 +324,7 @@ func TestAddMethod(t *testing.T) {
 				RubyObject: &testRubyObject{
 					class: &class{
 						name:            "base class",
-						instanceMethods: map[string]RubyMethod{},
+						instanceMethods: NewMethodSet(map[string]RubyMethod{}),
 						superClass:      objectClass,
 					},
 				},
@@ -347,13 +347,13 @@ func TestAddMethod(t *testing.T) {
 
 		newContext := AddMethod(context, "foo", fn)
 
-		_, ok := newContext.Class().Methods()["foo"]
+		_, ok := newContext.Class().Methods().Get("foo")
 		if !ok {
 			t.Logf("Expected object to have method foo")
 			t.Fail()
 		}
 
-		_, ok = newContext.Class().Methods()["bar"]
+		_, ok = newContext.Class().Methods().Get("bar")
 		if !ok {
 			t.Logf("Expected object to have method bar")
 			t.Fail()


### PR DESCRIPTION
This enables us to make the methods thread safe when it comes to concurrent
calls to the method sets