### PR TITLE
Extend the environment type

### DIFF
--- a/object/environment_test.go
+++ b/object/environment_test.go
@@ -2,6 +2,129 @@ package object
 
 import "testing"
 
+func TestEnvStat(t *testing.T) {
+	t.Run("top level env", func(t *testing.T) {
+		obj := &Integer{42}
+
+		env := &environment{store: map[string]RubyObject{"foo": obj}}
+
+		info, ok := EnvStat(env, obj)
+
+		if !ok {
+			t.Logf("Expected obj to be found in env")
+			t.FailNow()
+		}
+
+		expectedName := "foo"
+		expectedEnv := env
+
+		if expectedName != info.Name() {
+			t.Logf("Expected info.Name to equal %q, got %q", expectedName, info.Name())
+			t.Fail()
+		}
+
+		if expectedEnv != info.Env() {
+			t.Logf("Expected env to equal\n%+#v\ngot\n\t%+#v\n", expectedEnv, info.Env())
+			t.Fail()
+		}
+	})
+	t.Run("two level nested", func(t *testing.T) {
+		obj := &Integer{42}
+
+		root := &environment{store: map[string]RubyObject{"foo": obj}}
+		outer := &environment{store: make(map[string]RubyObject), outer: root}
+		env := &environment{store: make(map[string]RubyObject), outer: outer}
+
+		info, ok := EnvStat(env, obj)
+
+		if !ok {
+			t.Logf("Expected obj to be found in env")
+			t.FailNow()
+		}
+
+		expectedName := "foo"
+		expectedEnv := root
+
+		if expectedName != info.Name() {
+			t.Logf("Expected info.Name to equal %q, got %q", expectedName, info.Name())
+			t.Fail()
+		}
+
+		if expectedEnv != info.Env() {
+			t.Logf("Expected env to equal\n%+#v\ngot\n\t%+#v\n", expectedEnv, info.Env())
+			t.Fail()
+		}
+	})
+	t.Run("two level nested same value with different keys", func(t *testing.T) {
+		obj := &Integer{42}
+
+		root := &environment{store: map[string]RubyObject{"foo": obj}}
+		outer := &environment{store: map[string]RubyObject{"bar": obj}, outer: root}
+		env := &environment{store: make(map[string]RubyObject), outer: outer}
+
+		info, ok := EnvStat(env, obj)
+
+		if !ok {
+			t.Logf("Expected obj to be found in env")
+			t.FailNow()
+		}
+
+		expectedName := "bar"
+		expectedEnv := outer
+
+		if expectedName != info.Name() {
+			t.Logf("Expected info.Name to equal %q, got %q", expectedName, info.Name())
+			t.Fail()
+		}
+
+		if expectedEnv != info.Env() {
+			t.Logf("Expected env to equal\n%+#v\ngot\n\t%+#v\n", expectedEnv, info.Env())
+			t.Fail()
+		}
+	})
+	t.Run("two level nested overshadowed key", func(t *testing.T) {
+		obj := &Integer{42}
+
+		root := &environment{store: map[string]RubyObject{"foo": obj}}
+		outer := &environment{store: map[string]RubyObject{"foo": TRUE}, outer: root}
+		env := &environment{store: make(map[string]RubyObject), outer: outer}
+
+		info, ok := EnvStat(env, obj)
+
+		if !ok {
+			t.Logf("Expected obj to be found in env")
+			t.FailNow()
+		}
+
+		expectedName := "foo"
+		expectedEnv := root
+
+		if expectedName != info.Name() {
+			t.Logf("Expected info.Name to equal %q, got %q", expectedName, info.Name())
+			t.Fail()
+		}
+
+		if expectedEnv != info.Env() {
+			t.Logf("Expected env to equal\n%+#v\ngot\n\t%+#v\n", expectedEnv, info.Env())
+			t.Fail()
+		}
+	})
+	t.Run("two level nested not found", func(t *testing.T) {
+		obj := &Integer{42}
+
+		root := &environment{store: map[string]RubyObject{"foo": FALSE}}
+		outer := &environment{store: map[string]RubyObject{"bar": TRUE}, outer: root}
+		env := &environment{store: make(map[string]RubyObject), outer: outer}
+
+		_, ok := EnvStat(env, obj)
+
+		if ok {
+			t.Logf("Expected obj not to be found in env")
+			t.FailNow()
+		}
+	})
+}
+
 func TestEnvironmentSet(t *testing.T) {
 	env := &environment{store: make(map[string]RubyObject)}
 


### PR DESCRIPTION
This allows us to set namespaces on envs, which will be needed later when the
scoping operator, a.k.a. `::` will be introduced. Also it contains the possibility
to search for objects within a given env and its hierarchy.