### PR TITLE
Give the top level Self the name `main`

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -77,7 +77,7 @@ func Eval(node ast.Node, env object.Environment) (object.RubyObject, error) {
 		return val, nil
 	case *ast.ModuleExpression:
 		module := object.NewModule(node.Name.Value, nil)
-		env.Set("self", &object.Self{module})
+		env.Set("self", &object.Self{module, node.Name.Value})
 		defer env.Unset("self")
 		bodyReturn, err := Eval(node.Body, env)
 		if err != nil {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -195,7 +195,7 @@ end
 		},
 		{
 			"foobar",
-			"NameError: undefined local variable or method `foobar' for :Object",
+			"NameError: undefined local variable or method `foobar' for main:Object",
 		},
 		{
 			"Foobar",
@@ -214,7 +214,7 @@ end
 
 	for _, tt := range tests {
 		env := object.NewEnvironment()
-		env.Set("self", &object.Self{&object.Object{}})
+		env.Set("self", &object.Self{&object.Object{}, "main"})
 		evaluated, err := testEval(tt.input, env)
 
 		if err == nil {
@@ -352,7 +352,7 @@ func TestFunctionObject(t *testing.T) {
 
 	for _, tt := range tests {
 		env := object.NewEnvironment()
-		env.Set("self", &object.Self{&object.Object{}})
+		env.Set("self", &object.Self{&object.Object{}, "main"})
 		evaluated, err := testEval(tt.input, env)
 		checkError(t, err)
 		sym, ok := evaluated.(*object.Symbol)
@@ -412,7 +412,7 @@ func TestFunctionApplication(t *testing.T) {
 
 	for _, tt := range tests {
 		env := object.NewEnvironment()
-		env.Set("self", &object.Self{&object.Object{}})
+		env.Set("self", &object.Self{&object.Object{}, "main"})
 		evaluated, err := testEval(tt.input, env)
 		checkError(t, err)
 		testIntegerObject(t, evaluated, tt.expected)
@@ -565,7 +565,7 @@ func TestSelfExpression(t *testing.T) {
 	input := "self"
 
 	env := object.NewMainEnvironment()
-	env.Set("self", &object.Self{&object.Integer{Value: 3}})
+	env.Set("self", &object.Self{&object.Integer{Value: 3}, "3"})
 	evaluated, err := testEval(input, env)
 	checkError(t, err)
 

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -289,7 +289,7 @@ func TestModuleObject(t *testing.T) {
 
 	for _, tt := range tests {
 		env := object.NewEnvironment()
-		env.Set("self", &object.Self{&object.Object{}})
+		env.Set("self", &object.Self{&object.Object{}, "main"})
 		evaluated, err := testEval(tt.input, env)
 		checkError(t, err)
 

--- a/object/environment.go
+++ b/object/environment.go
@@ -6,7 +6,7 @@ var classes = NewEnvironment()
 // and the Kernel functions
 func NewMainEnvironment() Environment {
 	env := classes.Clone()
-	env.Set("self", &Self{&Object{}})
+	env.Set("self", &Self{&Object{}, "main"})
 	env.SetGlobal("$LOADED_FEATURES", NewArray())
 	return env
 }

--- a/object/ruby_object.go
+++ b/object/ruby_object.go
@@ -153,10 +153,14 @@ func (f *Function) unwrapReturnValue(obj RubyObject) RubyObject {
 // self in the given context.
 type Self struct {
 	RubyObject
+	Name string
 }
 
 // Type returns SELF
 func (s *Self) Type() Type { return SELF }
+
+// Inspect returns the name of Self
+func (s *Self) Inspect() string { return s.Name }
 
 // extendedObject is a wrapper object for an object extended by methods.
 type extendedObject struct {

--- a/object/send_test.go
+++ b/object/send_test.go
@@ -114,6 +114,7 @@ func TestSend(t *testing.T) {
 						},
 					},
 				},
+				"main",
 			},
 		}
 
@@ -269,6 +270,7 @@ func TestAddMethod(t *testing.T) {
 				instanceMethods: map[string]RubyMethod{},
 				superClass:      objectClass,
 			},
+			Name: "main",
 		}
 		context := &Self{
 			RubyObject: vanillaObject,
@@ -331,6 +333,7 @@ func TestAddMethod(t *testing.T) {
 					}),
 				}),
 			},
+			Name: "main",
 		}
 
 		fn := &Function{

--- a/object/send_test.go
+++ b/object/send_test.go
@@ -9,6 +9,7 @@ import (
 
 type testRubyObject struct {
 	class RubyClassObject
+	Name  string
 }
 
 func (t *testRubyObject) Type() Type      { return Type("TEST_OBJECT") }


### PR DESCRIPTION
This will further allow us to add namespaces on the level of self, like when introducing
modules.

Side effect: the not found error for main is similar to the Ruby MRI one.