### PR TITLE
Add introspection methods on Kernel and Module

### DIFF
--- a/object/introspect.go
+++ b/object/introspect.go
@@ -1,0 +1,19 @@
+package object
+
+func getMethods(class RubyClass, visibility MethodVisibility, addSuperMethods bool) *Array {
+	var methodSymbols []RubyObject
+	for class != nil {
+		methods := class.Methods().GetAll()
+		for meth, fn := range methods {
+			if fn.Visibility() == visibility {
+				methodSymbols = append(methodSymbols, &Symbol{meth})
+			}
+		}
+		if !addSuperMethods {
+			break
+		}
+		class = class.SuperClass()
+	}
+
+	return &Array{Elements: methodSymbols}
+}

--- a/object/introspect_test.go
+++ b/object/introspect_test.go
@@ -1,0 +1,158 @@
+package object
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestGetMethods(t *testing.T) {
+	superClassMethods := map[string]RubyMethod{
+		"super_foo":           publicMethod(nil),
+		"super_bar":           publicMethod(nil),
+		"protected_super_foo": protectedMethod(nil),
+		"private_super_foo":   privateMethod(nil),
+	}
+	contextMethods := map[string]RubyMethod{
+		"foo":           publicMethod(nil),
+		"bar":           publicMethod(nil),
+		"protected_foo": protectedMethod(nil),
+		"private_foo":   privateMethod(nil),
+	}
+	classWithoutSuperclass := &class{
+		instanceMethods: NewMethodSet(contextMethods),
+		superClass:      nil,
+	}
+	classWithSuperclass := &class{
+		instanceMethods: NewMethodSet(contextMethods),
+		superClass: &class{
+			instanceMethods: NewMethodSet(superClassMethods),
+			superClass:      nil,
+		},
+	}
+
+	tests := []struct {
+		name                 string
+		class                RubyClass
+		visibility           MethodVisibility
+		addSuperclassMethods bool
+		expectedMethods      []string
+	}{
+		{
+			"no superclass public methods add super methods",
+			classWithoutSuperclass,
+			PUBLIC_METHOD,
+			true,
+			[]string{":foo", ":bar"},
+		},
+		{
+			"no superclass public methods add no super methods",
+			classWithoutSuperclass,
+			PUBLIC_METHOD,
+			false,
+			[]string{":foo", ":bar"},
+		},
+		{
+			"no superclass protected methods add super methods",
+			classWithoutSuperclass,
+			PROTECTED_METHOD,
+			true,
+			[]string{":protected_foo"},
+		},
+		{
+			"no superclass protected methods add no super methods",
+			classWithoutSuperclass,
+			PROTECTED_METHOD,
+			false,
+			[]string{":protected_foo"},
+		},
+		{
+			"no superclass private methods add super methods",
+			classWithoutSuperclass,
+			PRIVATE_METHOD,
+			true,
+			[]string{":private_foo"},
+		},
+		{
+			"no superclass private methods add no super methods",
+			classWithoutSuperclass,
+			PRIVATE_METHOD,
+			false,
+			[]string{":private_foo"},
+		},
+		{
+			"with superclass public methods add super methods",
+			classWithSuperclass,
+			PUBLIC_METHOD,
+			true,
+			[]string{":foo", ":bar", ":super_foo", ":super_bar"},
+		},
+		{
+			"with superclass public methods add with super methods",
+			classWithSuperclass,
+			PUBLIC_METHOD,
+			false,
+			[]string{":foo", ":bar"},
+		},
+		{
+			"with superclass protected methods add super methods",
+			classWithSuperclass,
+			PROTECTED_METHOD,
+			true,
+			[]string{":protected_foo", ":protected_super_foo"},
+		},
+		{
+			"with superclass protected methods add with super methods",
+			classWithSuperclass,
+			PROTECTED_METHOD,
+			false,
+			[]string{":protected_foo"},
+		},
+		{
+			"with superclass private methods add super methods",
+			classWithSuperclass,
+			PRIVATE_METHOD,
+			true,
+			[]string{":private_foo", ":private_super_foo"},
+		},
+		{
+			"with superclass private methods add with super methods",
+			classWithSuperclass,
+			PRIVATE_METHOD,
+			false,
+			[]string{":private_foo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getMethods(tt.class, tt.visibility, tt.addSuperclassMethods)
+
+			var methods []string
+			for i, elem := range result.Elements {
+				sym, ok := elem.(*Symbol)
+				if !ok {
+					t.Logf("Expected all elements to be symbols, got %T at index %d", elem, i)
+					t.Fail()
+				} else {
+					methods = append(methods, sym.Inspect())
+				}
+			}
+
+			expectedLen := len(tt.expectedMethods)
+
+			if len(result.Elements) != expectedLen {
+				t.Logf("Expected %d items, got %d", expectedLen, len(result.Elements))
+				t.Fail()
+			}
+
+			sort.Strings(tt.expectedMethods)
+			sort.Strings(methods)
+
+			if !reflect.DeepEqual(tt.expectedMethods, methods) {
+				t.Logf("Expected methods to equal\n%s\n\tgot\n%s\n", tt.expectedMethods, methods)
+				t.Fail()
+			}
+		})
+	}
+}

--- a/object/kernel.go
+++ b/object/kernel.go
@@ -18,12 +18,15 @@ func init() {
 }
 
 var kernelMethodSet = map[string]RubyMethod{
-	"nil?":    withArity(0, publicMethod(kernelIsNil)),
-	"methods": publicMethod(kernelMethods),
-	"class":   withArity(0, publicMethod(kernelClass)),
-	"puts":    privateMethod(kernelPuts),
-	"require": withArity(1, privateMethod(kernelRequire)),
-	"extend":  publicMethod(kernelExtend),
+	"nil?":              withArity(0, publicMethod(kernelIsNil)),
+	"methods":           publicMethod(kernelPublicMethods),
+	"public_methods":    publicMethod(kernelPublicMethods),
+	"protected_methods": publicMethod(kernelProtectedMethods),
+	"private_methods":   publicMethod(kernelPrivateMethods),
+	"class":             withArity(0, publicMethod(kernelClass)),
+	"puts":              privateMethod(kernelPuts),
+	"require":           withArity(1, privateMethod(kernelRequire)),
+	"extend":            publicMethod(kernelExtend),
 }
 
 func kernelPuts(context CallContext, args ...RubyObject) (RubyObject, error) {
@@ -35,7 +38,7 @@ func kernelPuts(context CallContext, args ...RubyObject) (RubyObject, error) {
 	return NIL, nil
 }
 
-func kernelMethods(context CallContext, args ...RubyObject) (RubyObject, error) {
+func kernelPublicMethods(context CallContext, args ...RubyObject) (RubyObject, error) {
 	showSuperClassMethods := true
 	if len(args) == 1 {
 		boolean, ok := args[0].(*Boolean)
@@ -46,6 +49,32 @@ func kernelMethods(context CallContext, args ...RubyObject) (RubyObject, error) 
 	}
 	class := context.Receiver().Class()
 	return getMethods(class, PUBLIC_METHOD, showSuperClassMethods), nil
+}
+
+func kernelProtectedMethods(context CallContext, args ...RubyObject) (RubyObject, error) {
+	showSuperClassMethods := true
+	if len(args) == 1 {
+		boolean, ok := args[0].(*Boolean)
+		if !ok {
+			boolean = TRUE.(*Boolean)
+		}
+		showSuperClassMethods = boolean.Value
+	}
+	class := context.Receiver().Class()
+	return getMethods(class, PROTECTED_METHOD, showSuperClassMethods), nil
+}
+
+func kernelPrivateMethods(context CallContext, args ...RubyObject) (RubyObject, error) {
+	showSuperClassMethods := true
+	if len(args) == 1 {
+		boolean, ok := args[0].(*Boolean)
+		if !ok {
+			boolean = TRUE.(*Boolean)
+		}
+		showSuperClassMethods = boolean.Value
+	}
+	class := context.Receiver().Class()
+	return getMethods(class, PRIVATE_METHOD, showSuperClassMethods), nil
 }
 
 func kernelIsNil(context CallContext, args ...RubyObject) (RubyObject, error) {

--- a/object/kernel_test.go
+++ b/object/kernel_test.go
@@ -30,7 +30,7 @@ func TestKernelMethods(t *testing.T) {
 			},
 		}
 
-		result, err := kernelMethods(context)
+		result, err := kernelPublicMethods(context)
 
 		checkError(t, err, nil)
 
@@ -83,7 +83,7 @@ func TestKernelMethods(t *testing.T) {
 			},
 		}
 
-		result, err := kernelMethods(context)
+		result, err := kernelPublicMethods(context)
 
 		checkError(t, err, nil)
 
@@ -136,7 +136,7 @@ func TestKernelMethods(t *testing.T) {
 			},
 		}
 
-		result, err := kernelMethods(context, FALSE)
+		result, err := kernelPublicMethods(context, FALSE)
 
 		checkError(t, err, nil)
 
@@ -189,7 +189,7 @@ func TestKernelMethods(t *testing.T) {
 			},
 		}
 
-		result, err := kernelMethods(context, TRUE)
+		result, err := kernelPublicMethods(context, TRUE)
 
 		checkError(t, err, nil)
 
@@ -316,11 +316,9 @@ func TestKernelRequire(t *testing.T) {
 	t.Run("wiring together", func(t *testing.T) {
 		evalCallCount := 0
 		var evalCallASTNode ast.Node
-		var evalCallEnv Environment
 		eval := func(node ast.Node, env Environment) (RubyObject, error) {
 			evalCallCount++
 			evalCallASTNode = node
-			evalCallEnv = env
 			return TRUE, nil
 		}
 

--- a/object/module.go
+++ b/object/module.go
@@ -45,8 +45,8 @@ func (m *Module) addMethod(name string, method RubyMethod) {
 var moduleMethods = map[string]RubyMethod{
 	"ancestors":                  withArity(0, publicMethod(moduleAncestors)),
 	"included_modules":           withArity(0, publicMethod(moduleIncludedModules)),
-	"instance_methods":           publicMethod(moduleInstanceMethods),
-	"public_instance_methods":    publicMethod(moduleInstanceMethods),
+	"instance_methods":           publicMethod(modulePublicInstanceMethods),
+	"public_instance_methods":    publicMethod(modulePublicInstanceMethods),
 	"protected_instance_methods": publicMethod(moduleProtectedInstanceMethods),
 	"private_instance_methods":   publicMethod(modulePrivateInstanceMethods),
 }
@@ -96,7 +96,7 @@ func moduleIncludedModules(context CallContext, args ...RubyObject) (RubyObject,
 	return &Array{includedModules}, nil
 }
 
-func moduleInstanceMethods(context CallContext, args ...RubyObject) (RubyObject, error) {
+func modulePublicInstanceMethods(context CallContext, args ...RubyObject) (RubyObject, error) {
 	showSuperClassInstanceMethods := true
 	if len(args) == 1 {
 		boolean, ok := args[0].(*Boolean)

--- a/object/module.go
+++ b/object/module.go
@@ -43,7 +43,12 @@ func (m *Module) addMethod(name string, method RubyMethod) {
 }
 
 var moduleMethods = map[string]RubyMethod{
-	"ancestors": withArity(0, publicMethod(moduleAncestors)),
+	"ancestors":                  withArity(0, publicMethod(moduleAncestors)),
+	"included_modules":           withArity(0, publicMethod(moduleIncludedModules)),
+	"instance_methods":           publicMethod(moduleInstanceMethods),
+	"public_instance_methods":    publicMethod(moduleInstanceMethods),
+	"protected_instance_methods": publicMethod(moduleProtectedInstanceMethods),
+	"private_instance_methods":   publicMethod(modulePrivateInstanceMethods),
 }
 
 func moduleAncestors(context CallContext, args ...RubyObject) (RubyObject, error) {
@@ -89,4 +94,46 @@ func moduleIncludedModules(context CallContext, args ...RubyObject) (RubyObject,
 	}
 
 	return &Array{includedModules}, nil
+}
+
+func moduleInstanceMethods(context CallContext, args ...RubyObject) (RubyObject, error) {
+	showSuperClassInstanceMethods := true
+	if len(args) == 1 {
+		boolean, ok := args[0].(*Boolean)
+		if !ok {
+			boolean = TRUE.(*Boolean)
+		}
+		showSuperClassInstanceMethods = boolean.Value
+	}
+	class := context.Receiver().(RubyClass)
+
+	return getMethods(class, PUBLIC_METHOD, showSuperClassInstanceMethods), nil
+}
+
+func moduleProtectedInstanceMethods(context CallContext, args ...RubyObject) (RubyObject, error) {
+	showSuperClassInstanceMethods := true
+	if len(args) == 1 {
+		boolean, ok := args[0].(*Boolean)
+		if !ok {
+			boolean = TRUE.(*Boolean)
+		}
+		showSuperClassInstanceMethods = boolean.Value
+	}
+	class := context.Receiver().(RubyClass)
+
+	return getMethods(class, PROTECTED_METHOD, showSuperClassInstanceMethods), nil
+}
+
+func modulePrivateInstanceMethods(context CallContext, args ...RubyObject) (RubyObject, error) {
+	showSuperClassInstanceMethods := true
+	if len(args) == 1 {
+		boolean, ok := args[0].(*Boolean)
+		if !ok {
+			boolean = TRUE.(*Boolean)
+		}
+		showSuperClassInstanceMethods = boolean.Value
+	}
+	class := context.Receiver().(RubyClass)
+
+	return getMethods(class, PRIVATE_METHOD, showSuperClassInstanceMethods), nil
 }

--- a/object/module_test.go
+++ b/object/module_test.go
@@ -2,6 +2,8 @@ package object
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -152,4 +154,218 @@ func TestModuleIncludedModules(t *testing.T) {
 		t.Logf("Expected modules to equal %s, got %s", expected, actual)
 		t.Fail()
 	}
+}
+
+func TestModuleInstanceMethods(t *testing.T) {
+	superClassMethods := map[string]RubyMethod{
+		"super_foo":         publicMethod(nil),
+		"super_bar":         publicMethod(nil),
+		"private_super_foo": privateMethod(nil),
+	}
+	contextMethods := map[string]RubyMethod{
+		"foo":         publicMethod(nil),
+		"bar":         publicMethod(nil),
+		"private_foo": privateMethod(nil),
+	}
+	t.Run("without superclass", func(t *testing.T) {
+		context := &callContext{
+			receiver: &class{
+				instanceMethods: NewMethodSet(contextMethods),
+				superClass:      nil,
+			},
+		}
+
+		result, err := moduleInstanceMethods(context)
+
+		checkError(t, err, nil)
+
+		array, ok := result.(*Array)
+		if !ok {
+			t.Logf("Expected array, got %T", result)
+			t.FailNow()
+		}
+
+		var methods []string
+		for i, elem := range array.Elements {
+			sym, ok := elem.(*Symbol)
+			if !ok {
+				t.Logf("Expected all elements to be symbols, got %T at index %d", elem, i)
+				t.Fail()
+			} else {
+				methods = append(methods, sym.Inspect())
+			}
+		}
+
+		var expectedMethods = []string{
+			":foo", ":bar",
+		}
+
+		expectedLen := len(expectedMethods)
+
+		if len(array.Elements) != expectedLen {
+			t.Logf("Expected %d items, got %d", expectedLen, len(array.Elements))
+			t.Fail()
+		}
+
+		sort.Strings(expectedMethods)
+		sort.Strings(methods)
+
+		if !reflect.DeepEqual(expectedMethods, methods) {
+			t.Logf("Expected methods to equal\n%s\n\tgot\n%s\n", expectedMethods, methods)
+			t.Fail()
+		}
+	})
+	t.Run("with superclass", func(t *testing.T) {
+		context := &callContext{
+			receiver: &class{
+				instanceMethods: NewMethodSet(contextMethods),
+				superClass: &class{
+					instanceMethods: NewMethodSet(superClassMethods),
+					superClass:      nil,
+				},
+			},
+		}
+
+		result, err := moduleInstanceMethods(context)
+
+		checkError(t, err, nil)
+
+		array, ok := result.(*Array)
+		if !ok {
+			t.Logf("Expected array, got %T", result)
+			t.FailNow()
+		}
+
+		var methods []string
+		for i, elem := range array.Elements {
+			sym, ok := elem.(*Symbol)
+			if !ok {
+				t.Logf("Expected all elements to be symbols, got %T at index %d", elem, i)
+				t.Fail()
+			} else {
+				methods = append(methods, sym.Inspect())
+			}
+		}
+
+		var expectedMethods = []string{
+			":foo", ":bar", ":super_foo", ":super_bar",
+		}
+
+		expectedLen := len(expectedMethods)
+
+		if len(array.Elements) != expectedLen {
+			t.Logf("Expected %d items, got %d", expectedLen, len(array.Elements))
+			t.Fail()
+		}
+
+		sort.Strings(expectedMethods)
+		sort.Strings(methods)
+
+		if !reflect.DeepEqual(expectedMethods, methods) {
+			t.Logf("Expected methods to equal\n%s\n\tgot\n%s\n", expectedMethods, methods)
+			t.Fail()
+		}
+	})
+	t.Run("with superclass but boolean arg false", func(t *testing.T) {
+		context := &callContext{
+			receiver: &class{
+				instanceMethods: NewMethodSet(contextMethods),
+				superClass: &class{
+					instanceMethods: NewMethodSet(superClassMethods),
+					superClass:      nil,
+				},
+			},
+		}
+
+		result, err := moduleInstanceMethods(context, FALSE)
+
+		checkError(t, err, nil)
+
+		array, ok := result.(*Array)
+		if !ok {
+			t.Logf("Expected array, got %T", result)
+			t.FailNow()
+		}
+
+		var methods []string
+		for i, elem := range array.Elements {
+			sym, ok := elem.(*Symbol)
+			if !ok {
+				t.Logf("Expected all elements to be symbols, got %T at index %d", elem, i)
+				t.Fail()
+			} else {
+				methods = append(methods, sym.Inspect())
+			}
+		}
+
+		var expectedMethods = []string{
+			":foo", ":bar",
+		}
+
+		expectedLen := len(expectedMethods)
+
+		if len(array.Elements) != expectedLen {
+			t.Logf("Expected %d items, got %d", expectedLen, len(array.Elements))
+			t.Fail()
+		}
+
+		sort.Strings(expectedMethods)
+		sort.Strings(methods)
+
+		if !reflect.DeepEqual(expectedMethods, methods) {
+			t.Logf("Expected methods to equal\n%s\n\tgot\n%s\n", expectedMethods, methods)
+			t.Fail()
+		}
+	})
+	t.Run("with superclass and boolean arg true", func(t *testing.T) {
+		context := &callContext{
+			receiver: &class{
+				instanceMethods: NewMethodSet(contextMethods),
+				superClass: &class{
+					instanceMethods: NewMethodSet(superClassMethods),
+					superClass:      nil,
+				},
+			},
+		}
+
+		result, err := moduleInstanceMethods(context, TRUE)
+
+		checkError(t, err, nil)
+
+		array, ok := result.(*Array)
+		if !ok {
+			t.Logf("Expected array, got %T", result)
+			t.FailNow()
+		}
+
+		var methods []string
+		for i, elem := range array.Elements {
+			sym, ok := elem.(*Symbol)
+			if !ok {
+				t.Logf("Expected all elements to be symbols, got %T at index %d", elem, i)
+				t.Fail()
+			} else {
+				methods = append(methods, sym.Inspect())
+			}
+		}
+
+		var expectedMethods = []string{
+			":foo", ":bar", ":super_foo", ":super_bar",
+		}
+
+		expectedLen := len(expectedMethods)
+
+		if len(array.Elements) != expectedLen {
+			t.Logf("Expected %d items, got %d", expectedLen, len(array.Elements))
+			t.Fail()
+		}
+
+		sort.Strings(expectedMethods)
+		sort.Strings(methods)
+
+		if !reflect.DeepEqual(expectedMethods, methods) {
+			t.Logf("Expected methods to equal\n%s\n\tgot\n%s\n", expectedMethods, methods)
+			t.Fail()
+		}
+	})
 }

--- a/object/module_test.go
+++ b/object/module_test.go
@@ -175,7 +175,7 @@ func TestModuleInstanceMethods(t *testing.T) {
 			},
 		}
 
-		result, err := moduleInstanceMethods(context)
+		result, err := modulePublicInstanceMethods(context)
 
 		checkError(t, err, nil)
 
@@ -226,7 +226,7 @@ func TestModuleInstanceMethods(t *testing.T) {
 			},
 		}
 
-		result, err := moduleInstanceMethods(context)
+		result, err := modulePublicInstanceMethods(context)
 
 		checkError(t, err, nil)
 
@@ -277,7 +277,7 @@ func TestModuleInstanceMethods(t *testing.T) {
 			},
 		}
 
-		result, err := moduleInstanceMethods(context, FALSE)
+		result, err := modulePublicInstanceMethods(context, FALSE)
 
 		checkError(t, err, nil)
 
@@ -328,7 +328,7 @@ func TestModuleInstanceMethods(t *testing.T) {
 			},
 		}
 
-		result, err := moduleInstanceMethods(context, TRUE)
+		result, err := modulePublicInstanceMethods(context, TRUE)
 
 		checkError(t, err, nil)
 


### PR DESCRIPTION
Includes:
- Kernel.public_methods
- Kernel.protected_methods
- Kernel.private_methods
- Module.instance_methods
- Module.public_instance_methods
- Module.protected_instance_methods
- Module.private_instance_methods

Also includes a fix for Kernel.methods, which uses the boolean arg properly
and returns always public and protected methods from the class hierarchy.