### PR TITLE
Add code blocks to core methods

### DIFF
--- a/interpreter/method_calls_test.go
+++ b/interpreter/method_calls_test.go
@@ -131,3 +131,25 @@ func TestMethodBlockLeakage(t *testing.T) {
 		}
 	})
 }
+
+func TestKernelTap(t *testing.T) {
+	input := `
+		x = []
+		x.tap {|z|z.push(true)}
+	`
+	i := New()
+
+	evaluated, err := i.Interpret(input)
+	if err != nil {
+		t.Logf("Expected no error, got %T:%v", err, err)
+		t.FailNow()
+	}
+
+	expected := &object.Array{Elements: []object.RubyObject{object.TRUE}}
+	actual := evaluated
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Logf("Expected result to equal\n%+#v\n\tgot\n%+#v\n", expected, actual)
+		t.Fail()
+	}
+}

--- a/object/array.go
+++ b/object/array.go
@@ -46,4 +46,14 @@ func (a *Array) Class() RubyClass { return arrayClass }
 
 var arrayClassMethods = map[string]RubyMethod{}
 
-var arrayMethods = map[string]RubyMethod{}
+var arrayMethods = map[string]RubyMethod{
+	"push": publicMethod(arrayPush),
+}
+
+func arrayPush(context CallContext, args ...RubyObject) (RubyObject, error) {
+	array, _ := context.Receiver().(*Array)
+	for _, item := range args {
+		array.Elements = append(array.Elements, item)
+	}
+	return array, nil
+}

--- a/object/array_test.go
+++ b/object/array_test.go
@@ -1,0 +1,51 @@
+package object
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestArrayPush(t *testing.T) {
+	t.Run("one argument", func(t *testing.T) {
+		array := &Array{}
+		env := NewEnvironment()
+		context := &callContext{
+			receiver: array,
+			env:      env,
+		}
+
+		result, err := arrayPush(context, &Integer{Value: 17})
+
+		checkError(t, err, nil)
+
+		expectedResult := &Array{Elements: []RubyObject{&Integer{Value: 17}}}
+
+		checkResult(t, result, expectedResult)
+
+		if !reflect.DeepEqual(expectedResult, array) {
+			t.Logf("Expected array to equal\n%+#v\n\tgot\n%+#v\n", expectedResult, array)
+			t.Fail()
+		}
+	})
+	t.Run("more than one argument", func(t *testing.T) {
+		array := &Array{}
+		env := NewEnvironment()
+		context := &callContext{
+			receiver: array,
+			env:      env,
+		}
+
+		result, err := arrayPush(context, &Integer{Value: 17}, NIL, TRUE, FALSE)
+
+		checkError(t, err, nil)
+
+		expectedResult := &Array{Elements: []RubyObject{&Integer{Value: 17}, NIL, TRUE, FALSE}}
+
+		checkResult(t, result, expectedResult)
+
+		if !reflect.DeepEqual(expectedResult, array) {
+			t.Logf("Expected array to equal\n%+#v\n\tgot\n%+#v\n", expectedResult, array)
+			t.Fail()
+		}
+	})
+}

--- a/object/kernel.go
+++ b/object/kernel.go
@@ -28,6 +28,7 @@ var kernelMethodSet = map[string]RubyMethod{
 	"require":           withArity(1, privateMethod(kernelRequire)),
 	"extend":            publicMethod(kernelExtend),
 	"block_given?":      withArity(0, privateMethod(kernelBlockGiven)),
+	"tap":               publicMethod(kernelTap),
 }
 
 func kernelPuts(context CallContext, args ...RubyObject) (RubyObject, error) {
@@ -200,4 +201,19 @@ func kernelBlockGiven(context CallContext, args ...RubyObject) (RubyObject, erro
 		return FALSE, nil
 	}
 	return TRUE, nil
+}
+
+func kernelTap(context CallContext, args ...RubyObject) (RubyObject, error) {
+	block, remainingArgs, ok := extractBlockFromArgs(args)
+	if !ok {
+		return nil, NewNoBlockGivenLocalJumpError()
+	}
+	if len(remainingArgs) != 0 {
+		return nil, NewWrongNumberOfArgumentsError(0, 1)
+	}
+	_, err := block.Call(context, context.Receiver())
+	if err != nil {
+		return nil, err
+	}
+	return context.Receiver(), nil
 }

--- a/object/kernel_test.go
+++ b/object/kernel_test.go
@@ -814,3 +814,96 @@ func TestKernelBlockGiven(t *testing.T) {
 		checkResult(t, result, FALSE)
 	})
 }
+
+func TestKernelTap(t *testing.T) {
+	t.Run("with block", func(t *testing.T) {
+		object := &Object{}
+		env := NewEnvironment()
+		eval := func(node ast.Node, env Environment) (RubyObject, error) {
+			return TRUE, nil
+		}
+		context := &callContext{
+			receiver: object,
+			env:      env,
+			eval:     eval,
+		}
+
+		block := &Proc{
+			Parameters: []*ast.Identifier{&ast.Identifier{Value: "o"}},
+			Body:       &ast.BlockStatement{Statements: []ast.Statement{}},
+			Env:        NewEnvironment(),
+		}
+
+		result, err := kernelTap(context, block)
+
+		checkError(t, err, nil)
+
+		checkResult(t, result, object)
+	})
+	t.Run("with args and block", func(t *testing.T) {
+		object := &Object{}
+		env := NewEnvironment()
+		eval := func(node ast.Node, env Environment) (RubyObject, error) {
+			return TRUE, nil
+		}
+		context := &callContext{
+			receiver: object,
+			env:      env,
+			eval:     eval,
+		}
+
+		block := &Proc{
+			Parameters: []*ast.Identifier{&ast.Identifier{Value: "o"}},
+			Body:       &ast.BlockStatement{Statements: []ast.Statement{}},
+			Env:        NewEnvironment(),
+		}
+
+		_, err := kernelTap(context, NIL, block)
+
+		expected := NewWrongNumberOfArgumentsError(0, 1)
+
+		checkError(t, err, expected)
+	})
+	t.Run("without block", func(t *testing.T) {
+		object := &Object{}
+		env := NewEnvironment()
+		eval := func(node ast.Node, env Environment) (RubyObject, error) {
+			return TRUE, nil
+		}
+		context := &callContext{
+			receiver: object,
+			env:      env,
+			eval:     eval,
+		}
+
+		_, err := kernelTap(context)
+
+		expectedError := NewNoBlockGivenLocalJumpError()
+
+		checkError(t, err, expectedError)
+	})
+	t.Run("with block error", func(t *testing.T) {
+		object := &Object{}
+		env := NewEnvironment()
+		eval := func(node ast.Node, env Environment) (RubyObject, error) {
+			return nil, NewException("An error")
+		}
+		context := &callContext{
+			receiver: object,
+			env:      env,
+			eval:     eval,
+		}
+
+		block := &Proc{
+			Parameters: []*ast.Identifier{},
+			Body:       &ast.BlockStatement{Statements: []ast.Statement{}},
+			Env:        NewEnvironment(),
+		}
+
+		_, err := kernelTap(context, block)
+
+		expected := NewException("An error")
+
+		checkError(t, err, expected)
+	})
+}

--- a/object/proc.go
+++ b/object/proc.go
@@ -15,6 +15,18 @@ func init() {
 	classes.Set("Proc", procClass)
 }
 
+func extractBlockFromArgs(args []RubyObject) (*Proc, []RubyObject, bool) {
+	if len(args) == 0 {
+		return nil, args, false
+	}
+	block, ok := args[len(args)-1].(*Proc)
+	if !ok {
+		return nil, args, false
+	}
+	args = args[:len(args)-1]
+	return block, args, true
+}
+
 // A Proc represents a user defined block of code.
 type Proc struct {
 	Parameters []*ast.Identifier

--- a/object/proc_test.go
+++ b/object/proc_test.go
@@ -1,0 +1,103 @@
+package object
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractBlockFromArgs(t *testing.T) {
+	t.Run("args empty", func(t *testing.T) {
+		args := []RubyObject{}
+
+		block, remaining, ok := extractBlockFromArgs(args)
+
+		if ok {
+			t.Logf("Expected no block found")
+			t.Fail()
+		}
+
+		if block != nil {
+			t.Logf("Expected block to be nil, got %+#v\n", block)
+			t.Fail()
+		}
+
+		if len(remaining) != 0 {
+			t.Logf("Expected remaining args to have length %d, got %d", 0, len(remaining))
+			t.Fail()
+		}
+	})
+	t.Run("args with block only", func(t *testing.T) {
+		args := []RubyObject{&Proc{}}
+
+		block, remaining, ok := extractBlockFromArgs(args)
+
+		if !ok {
+			t.Logf("Expected block found")
+			t.Fail()
+		}
+
+		if block == nil {
+			t.Logf("Expected block not to be nil")
+			t.Fail()
+		}
+
+		if len(remaining) != 0 {
+			t.Logf("Expected remaining args to have length %d, got %d", 0, len(remaining))
+			t.Fail()
+		}
+	})
+	t.Run("args with nil and block", func(t *testing.T) {
+		args := []RubyObject{NIL, &Proc{}}
+
+		block, remaining, ok := extractBlockFromArgs(args)
+
+		if !ok {
+			t.Logf("Expected block found")
+			t.Fail()
+		}
+
+		if block == nil {
+			t.Logf("Expected block not to be nil")
+			t.Fail()
+		}
+
+		if len(remaining) != 1 {
+			t.Logf("Expected remaining args to have length %d, got %d", 1, len(remaining))
+			t.Fail()
+		}
+
+		expected := []RubyObject{NIL}
+
+		if !reflect.DeepEqual(expected, remaining) {
+			t.Logf("Expected remaining args to equal\n%+#v\n\tgot\n%+#v\n", expected, remaining)
+			t.Fail()
+		}
+	})
+	t.Run("args with nil and block but block not at the end", func(t *testing.T) {
+		args := []RubyObject{&Proc{}, NIL}
+
+		block, remaining, ok := extractBlockFromArgs(args)
+
+		if ok {
+			t.Logf("Expected no block found")
+			t.Fail()
+		}
+
+		if block != nil {
+			t.Logf("Expected block to be nil, got %+#v\n", block)
+			t.Fail()
+		}
+
+		if len(remaining) != 2 {
+			t.Logf("Expected remaining args to have length %d, got %d", 2, len(remaining))
+			t.Fail()
+		}
+
+		expected := []RubyObject{&Proc{}, NIL}
+
+		if !reflect.DeepEqual(expected, remaining) {
+			t.Logf("Expected remaining args to equal\n%+#v\n\tgot\n%+#v\n", expected, remaining)
+			t.Fail()
+		}
+	})
+}

--- a/object/proc_test.go
+++ b/object/proc_test.go
@@ -3,6 +3,8 @@ package object
 import (
 	"reflect"
 	"testing"
+
+	"github.com/goruby/goruby/ast"
 )
 
 func TestExtractBlockFromArgs(t *testing.T) {
@@ -99,5 +101,50 @@ func TestExtractBlockFromArgs(t *testing.T) {
 			t.Logf("Expected remaining args to equal\n%+#v\n\tgot\n%+#v\n", expected, remaining)
 			t.Fail()
 		}
+	})
+}
+
+func TestProcCall(t *testing.T) {
+	t.Run("argument count not mandatory", func(t *testing.T) {
+		proc := &Proc{
+			Parameters: []*ast.Identifier{&ast.Identifier{Value: "a"}},
+			Body:       &ast.BlockStatement{Statements: []ast.Statement{}},
+			Env:        NewEnvironment(),
+			ArgumentCountMandatory: false,
+		}
+		eval := func(node ast.Node, env Environment) (RubyObject, error) {
+			return TRUE, nil
+		}
+		context := &callContext{
+			receiver: NIL,
+			env:      NewEnvironment(),
+			eval:     eval,
+		}
+
+		_, err := proc.Call(context)
+
+		checkError(t, err, nil)
+	})
+	t.Run("argument count mandatory", func(t *testing.T) {
+		proc := &Proc{
+			Parameters: []*ast.Identifier{&ast.Identifier{Value: "a"}},
+			Body:       &ast.BlockStatement{Statements: []ast.Statement{}},
+			Env:        NewEnvironment(),
+			ArgumentCountMandatory: true,
+		}
+		eval := func(node ast.Node, env Environment) (RubyObject, error) {
+			return TRUE, nil
+		}
+		context := &callContext{
+			receiver: NIL,
+			env:      NewEnvironment(),
+			eval:     eval,
+		}
+
+		_, err := proc.Call(context)
+
+		expected := NewWrongNumberOfArgumentsError(1, 0)
+
+		checkError(t, err, expected)
 	})
 }

--- a/object/ruby_object.go
+++ b/object/ruby_object.go
@@ -110,7 +110,7 @@ func (f *Function) Class() RubyClass { return nil }
 
 // Call implements the RubyMethod interface. It evaluates f.Body and returns its result
 func (f *Function) Call(context CallContext, args ...RubyObject) (RubyObject, error) {
-	block, arguments, _ := f.extractBlockFromArgs(args)
+	block, arguments, _ := extractBlockFromArgs(args)
 	if len(arguments) != len(f.Parameters) {
 		return nil, NewWrongNumberOfArgumentsError(len(f.Parameters), len(arguments))
 	}
@@ -144,18 +144,6 @@ func (f *Function) unwrapReturnValue(obj RubyObject) RubyObject {
 		return returnValue.Value
 	}
 	return obj
-}
-
-func (f *Function) extractBlockFromArgs(args []RubyObject) (*Proc, []RubyObject, bool) {
-	if len(args) == 0 {
-		return nil, args, false
-	}
-	block, ok := args[len(args)-1].(*Proc)
-	if !ok {
-		return nil, args, false
-	}
-	args = args[:len(args)-1]
-	return block, args, true
 }
 
 // Self represents the value associated to `self`. It acts as a wrapper around


### PR DESCRIPTION
This introduces code blocks for core methods.

Depends on [#37](https://github.com/goruby/goruby/pull/37) for block parsing