### PR TITLE
Implement hashes with hash rockets `=>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ To run the command as one off run `go run main.go`.
 	- [ ] default values for parameters
 	- [ ] keyword arguments
 	- [x] block arguments
+	- [ ] hash as last argument without braces
 - [x] function calls
 	- [x] with parens
 	- [x] without parens	
@@ -185,6 +186,10 @@ To run the command as one off run `go run main.go`.
 	- [ ] array of symbols `%i{}`
 - [x] nil
 - [ ] hashes
+	- [x] literal with `=>` notation
+	- [ ] literal with `key:` notation
+	- [x] indexing `hash[:foo]`
+	- [x] every Ruby Object can be a hash key
 - [ ] symbols
 	- [x] `:symbol`
 	- [x] `:"symbol"`

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 
 	"github.com/goruby/goruby/token"
@@ -362,6 +363,29 @@ func (al *ArrayLiteral) String() string {
 	out.WriteString("[")
 	out.WriteString(strings.Join(elements, ", "))
 	out.WriteString("]")
+	return out.String()
+}
+
+// HashLiteral represents an Hash literal within the AST
+type HashLiteral struct {
+	Token token.Token // the '{'
+	Map   map[Expression]Expression
+}
+
+func (hl *HashLiteral) expressionNode() {}
+func (hl *HashLiteral) literalNode()    {}
+
+// TokenLiteral returns the literal of the token token.LBRACE
+func (hl *HashLiteral) TokenLiteral() string { return hl.Token.Literal }
+func (hl *HashLiteral) String() string {
+	var out bytes.Buffer
+	elements := []string{}
+	for key, val := range hl.Map {
+		elements = append(elements, fmt.Sprintf("%q => %q", key.String(), val.String()))
+	}
+	out.WriteString("{")
+	out.WriteString(strings.Join(elements, ", "))
+	out.WriteString("}")
 	return out.String()
 }
 

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -116,6 +116,25 @@ func (bs *BlockStatement) String() string {
 	return out.String()
 }
 
+// Assignment represents a generic assignment
+type Assignment struct {
+	Token token.Token
+	Left  Expression
+	Right Expression
+}
+
+func (a *Assignment) String() string {
+	var out bytes.Buffer
+	out.WriteString(encloseInParensIfNeeded(a.Left))
+	out.WriteString(" = ")
+	out.WriteString(encloseInParensIfNeeded(a.Right))
+	return out.String()
+}
+func (a *Assignment) expressionNode() {}
+
+// TokenLiteral returns the literal of the ASSIGN token
+func (a *Assignment) TokenLiteral() string { return a.Token.Literal }
+
 // GlobalAssignment represents a global assignment
 type GlobalAssignment struct {
 	Name  *Global
@@ -127,13 +146,7 @@ func (v *GlobalAssignment) String() string {
 	out.WriteString(v.Name.String())
 	out.WriteString(" = ")
 	if v.Value != nil {
-		val := v.Value.String()
-		hasParens := strings.HasPrefix(val, "(") && strings.HasSuffix(val, ")")
-		_, isLiteral := v.Value.(literal)
-		if !isLiteral && !hasParens {
-			val = "(" + val + ")"
-		}
-		out.WriteString(val)
+		out.WriteString(encloseInParensIfNeeded(v.Value))
 	}
 	return out.String()
 }
@@ -153,13 +166,7 @@ func (v *VariableAssignment) String() string {
 	out.WriteString(v.Name.String())
 	out.WriteString(" = ")
 	if v.Value != nil {
-		val := v.Value.String()
-		hasParens := strings.HasPrefix(val, "(") && strings.HasSuffix(val, ")")
-		_, isLiteral := v.Value.(literal)
-		if !isLiteral && !hasParens {
-			val = "(" + val + ")"
-		}
-		out.WriteString(val)
+		out.WriteString(encloseInParensIfNeeded(v.Value))
 	}
 	return out.String()
 }
@@ -596,4 +603,14 @@ func (oe *InfixExpression) String() string {
 	out.WriteString(oe.Right.String())
 	out.WriteString(")")
 	return out.String()
+}
+
+func encloseInParensIfNeeded(expr Expression) string {
+	val := expr.String()
+	hasParens := strings.HasPrefix(val, "(") && strings.HasSuffix(val, ")")
+	_, isLiteral := expr.(literal)
+	if !isLiteral && !hasParens {
+		val = "(" + val + ")"
+	}
+	return val
 }

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -79,6 +79,10 @@ func Walk(v Visitor, node Node) {
 	case *ExpressionStatement:
 		Walk(v, n.Expression)
 
+	case *Assignment:
+		Walk(v, n.Left)
+		Walk(v, n.Right)
+
 	case *VariableAssignment:
 		Walk(v, n.Name)
 		Walk(v, n.Value)

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -95,6 +95,20 @@ func Eval(node ast.Node, env object.Environment) (object.RubyObject, error) {
 			return nil, err
 		}
 		return &object.Array{Elements: elements}, nil
+	case *ast.HashLiteral:
+		hashMap := make(map[object.RubyObject]object.RubyObject)
+		for k, v := range node.Map {
+			key, err := Eval(k, env)
+			if err != nil {
+				return nil, err
+			}
+			value, err := Eval(v, env)
+			if err != nil {
+				return nil, err
+			}
+			hashMap[key] = value
+		}
+		return &object.Hash{Map: hashMap}, nil
 
 	// Expressions
 	case *ast.VariableAssignment:

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -348,6 +348,66 @@ func TestScopedIdentifierExpression(t *testing.T) {
 	}
 }
 
+func TestAssignment(t *testing.T) {
+	t.Run("assign to hash", func(t *testing.T) {
+		tests := []struct {
+			input    string
+			expected int64
+		}{
+			{
+				`{:foo => 3}[:foo] = 5`,
+				5,
+			},
+		}
+
+		for _, tt := range tests {
+			evaluated, err := testEval(tt.input)
+			checkError(t, err)
+
+			testIntegerObject(t, evaluated, tt.expected)
+		}
+	})
+	t.Run("assign to array", func(t *testing.T) {
+		tests := []struct {
+			input    string
+			size     int
+			elements []object.RubyObject
+		}{
+			{
+				`x = [3]; x[0] = 5; x`,
+				1,
+				[]object.RubyObject{&object.Integer{Value: 5}},
+			},
+			{
+				`x = [3]; x[3] = 5; x`,
+				4,
+				[]object.RubyObject{&object.Integer{Value: 3}, object.NIL, object.NIL, &object.Integer{Value: 5}},
+			},
+		}
+
+		for _, tt := range tests {
+			evaluated, err := testEval(tt.input)
+			checkError(t, err)
+
+			array, ok := evaluated.(*object.Array)
+			if !ok {
+				t.Logf("Expected to eval to array, got %T\n", evaluated)
+				t.FailNow()
+			}
+
+			if len(array.Elements) != tt.size {
+				t.Logf("Expected array size to equal %d, got %d\n", tt.size, len(array.Elements))
+				t.Fail()
+			}
+
+			if !reflect.DeepEqual(array.Elements, tt.elements) {
+				t.Logf("Expected elements to equal\n%s\n\tgot\n%s\n", tt.elements, array.Elements)
+				t.Fail()
+			}
+		}
+	})
+}
+
 func TestVariableAssignmentExpression(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -947,6 +947,77 @@ func TestHashLiteral(t *testing.T) {
 	}
 }
 
+func TestHashIndexExpressions(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{
+			"{'foo' => 1, 'bar' => 2, 'qux' => 3}['foo']",
+			1,
+		},
+		{
+			"{'foo' => 1, 'bar' => 2, 'qux' => 3}['bar']",
+			2,
+		},
+		{
+			"{'foo' => 1, 'bar' => 2, 'qux' => 3}['qux']",
+			3,
+		},
+		{
+			"i = 'foo'; {'foo'=>1}[i];",
+			1,
+		},
+		{
+			"{1=>1, 2=>2, 3=>3}[1 + 1];",
+			2,
+		},
+		{
+			"myHash = {1=>1, 2=>2, 3=>3}; myHash[2];",
+			2,
+		},
+		{
+			"myHash = {0=>1, 1=>2, 2=>3}; myHash[0] + myHash[1] + myHash[2];",
+			6,
+		},
+		{
+			"myHash = {0=>1, 1=>2, 2=>3}; i = myHash[0]; myHash[i]",
+			2,
+		},
+		{
+			"{0=>1, 1=>2, 2=>3}[3]",
+			nil,
+		},
+		{
+			"{0=>1, 1=>2, 2=>3}[-1]",
+			nil,
+		},
+		{
+			"{:foo => 1, :bar => 2, :qux => 3}[:qux]",
+			3,
+		},
+		{
+			"{'foo' =>1, true => 2, false => 3}[true]",
+			2,
+		},
+		{
+			"{nil =>1, :qux => 2, 3=>3}[nil]",
+			1,
+		},
+	}
+
+	for _, tt := range tests {
+		evaluated, err := testEval(tt.input)
+		checkError(t, err)
+		integer, ok := tt.expected.(int)
+		if ok {
+			testIntegerObject(t, evaluated, int64(integer))
+		} else {
+			testNilObject(t, evaluated)
+		}
+	}
+}
+
 func testExceptionObject(t *testing.T, obj object.RubyObject, errorMessage string) {
 	if !IsError(obj) {
 		t.Logf("Expected error or exception, got %T", obj)

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -915,6 +915,38 @@ func TestSelfExpression(t *testing.T) {
 	testIntegerObject(t, self.RubyObject, 3)
 }
 
+func TestHashLiteral(t *testing.T) {
+	input := `{"foo" => 42, :bar => 2, true => false, nil => true, 2 => 2}`
+
+	env := object.NewMainEnvironment()
+	evaluated, err := testEval(input, env)
+	checkError(t, err)
+
+	hash, ok := evaluated.(*object.Hash)
+	if !ok {
+		t.Logf("Expected evaluated object to be *object.Hash, got=%T", evaluated)
+		t.FailNow()
+	}
+
+	expected := map[string]object.RubyObject{
+		"foo":  &object.Integer{Value: 42},
+		":bar": &object.Integer{Value: 2},
+		"true": object.FALSE,
+		"nil":  object.TRUE,
+		"2":    &object.Integer{Value: 2},
+	}
+
+	actual := make(map[string]object.RubyObject)
+	for k, v := range hash.Map {
+		actual[k.Inspect()] = v
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Logf("Expected hash to equal\n%s\n\tgot\n%s\n", expected, actual)
+		t.Fail()
+	}
+}
+
 func testExceptionObject(t *testing.T, obj object.RubyObject, errorMessage string) {
 	if !IsError(obj) {
 		t.Logf("Expected error or exception, got %T", obj)

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -937,7 +937,7 @@ func TestHashLiteral(t *testing.T) {
 	}
 
 	actual := make(map[string]object.RubyObject)
-	for k, v := range hash.Map {
+	for k, v := range hash.Map() {
 		actual[k.Inspect()] = v
 	}
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -148,6 +148,9 @@ func startLexer(l *Lexer) StateFn {
 		if l.peek() == '=' {
 			l.next()
 			l.emit(token.EQ)
+		} else if l.peek() == '>' {
+			l.next()
+			l.emit(token.HASHROCKET)
 		} else {
 			l.emit(token.ASSIGN)
 		}

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -56,6 +56,7 @@ add do |x|
 end
 yield
 A::B
+=>
 $foo;
 $Foo
 $@
@@ -218,6 +219,8 @@ $a`
 		{token.CONST, "A"},
 		{token.SCOPE, "::"},
 		{token.CONST, "B"},
+		{token.NEWLINE, "\n"},
+		{token.HASHROCKET, "=>"},
 		{token.NEWLINE, "\n"},
 		{token.GLOBAL, "$foo"},
 		{token.SEMICOLON, ";"},

--- a/object/array.go
+++ b/object/array.go
@@ -1,6 +1,9 @@
 package object
 
-import "strings"
+import (
+	"hash/fnv"
+	"strings"
+)
 
 var arrayClass RubyClassObject = newClass(
 	"Array",
@@ -43,6 +46,13 @@ func (a *Array) Inspect() string {
 
 // Class returns the class of the Array
 func (a *Array) Class() RubyClass { return arrayClass }
+func (a *Array) hashKey() hashKey {
+	h := fnv.New64a()
+	for _, e := range a.Elements {
+		h.Write(hash(e).bytes())
+	}
+	return hashKey{Type: a.Type(), Value: h.Sum64()}
+}
 
 var arrayClassMethods = map[string]RubyMethod{}
 

--- a/object/basic_object.go
+++ b/object/basic_object.go
@@ -1,6 +1,8 @@
 package object
 
-import "fmt"
+import (
+	"fmt"
+)
 
 var basicObjectClass RubyClassObject = newClass(
 	"BasicObject",
@@ -15,7 +17,9 @@ func init() {
 }
 
 // basicObject represents a basicObject object in Ruby
-type basicObject struct{}
+type basicObject struct {
+	_ int // for uniqueness
+}
 
 // Inspect returns empty string. BasicObjects do not have an `inspect` method.
 func (b *basicObject) Inspect() string {

--- a/object/boolean.go
+++ b/object/boolean.go
@@ -35,6 +35,16 @@ func (b *Boolean) Class() RubyClass {
 	return falseClass
 }
 
+func (b *Boolean) hashKey() hashKey {
+	var value uint64
+	if b.Value {
+		value = 1
+	} else {
+		value = 0
+	}
+	return hashKey{Type: b.Type(), Value: value}
+}
+
 var booleanTrueMethods = map[string]RubyMethod{}
 
 var booleanFalseMethods = map[string]RubyMethod{}

--- a/object/boolean_test.go
+++ b/object/boolean_test.go
@@ -1,0 +1,22 @@
+package object
+
+import "testing"
+
+func TestBoolean_hashKey(t *testing.T) {
+	hello1 := &Boolean{Value: true}
+	hello2 := &Boolean{Value: true}
+	diff1 := &Boolean{Value: false}
+	diff2 := &Boolean{Value: false}
+
+	if hello1.hashKey() != hello2.hashKey() {
+		t.Errorf("strings with same content have different hash keys")
+	}
+
+	if diff1.hashKey() != diff2.hashKey() {
+		t.Errorf("strings with same content have different hash keys")
+	}
+
+	if hello1.hashKey() == diff1.hashKey() {
+		t.Errorf("strings with different content have same hash keys")
+	}
+}

--- a/object/class.go
+++ b/object/class.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"fmt"
+	"hash/fnv"
 )
 
 var classClass RubyClassObject = &class{
@@ -88,6 +89,11 @@ func (c *class) SuperClass() RubyClass {
 }
 func (c *class) Methods() MethodSet {
 	return c.instanceMethods
+}
+func (c *class) hashKey() hashKey {
+	h := fnv.New64a()
+	h.Write([]byte(c.name))
+	return hashKey{Type: c.Type(), Value: h.Sum64()}
 }
 func (c *class) addMethod(name string, method RubyMethod) {
 	c.instanceMethods.Set(name, method)

--- a/object/class_test.go
+++ b/object/class_test.go
@@ -87,6 +87,25 @@ func TestClassInspect(t *testing.T) {
 	}
 }
 
+func TestClass_hashKey(t *testing.T) {
+	hello1 := &class{name: "Hello World"}
+	hello2 := &class{name: "Hello World"}
+	diff1 := &class{name: "My name is johnny"}
+	diff2 := &class{name: "My name is johnny"}
+
+	if hello1.hashKey() != hello2.hashKey() {
+		t.Errorf("strings with same content have different hash keys")
+	}
+
+	if diff1.hashKey() != diff2.hashKey() {
+		t.Errorf("strings with same content have different hash keys")
+	}
+
+	if hello1.hashKey() == diff1.hashKey() {
+		t.Errorf("strings with different content have same hash keys")
+	}
+}
+
 func TestClassInstanceInspect(t *testing.T) {
 	context := &classInstance{class: &class{name: "Foo"}}
 

--- a/object/hash.go
+++ b/object/hash.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"fmt"
+	"hash/fnv"
 	"strings"
 )
 
@@ -10,16 +11,73 @@ var hashClass RubyClassObject = newClass(
 	objectClass,
 	hashMethods,
 	hashClassMethods,
-	func(RubyClassObject) RubyObject { return &Hash{make(map[RubyObject]RubyObject)} },
+	func(RubyClassObject) RubyObject {
+		return &Hash{hashMap: make(map[hashKey]hashPair)}
+	},
 )
 
 func init() {
 	classes.Set("Hash", hashClass)
 }
 
+type hashKey struct {
+	Type  Type
+	Value uint64
+}
+
+func (h hashKey) bytes() []byte {
+	return append([]byte(h.Type), byte(h.Value))
+}
+
+func hash(obj RubyObject) hashKey {
+	if hashable, ok := obj.(hashable); ok {
+		return hashable.hashKey()
+	}
+	pointer := fmt.Sprintf("%p", obj)
+	h := fnv.New64a()
+	h.Write([]byte(pointer))
+	return hashKey{Type: obj.Type(), Value: h.Sum64()}
+}
+
+type hashPair struct {
+	Key   RubyObject
+	Value RubyObject
+}
+
 // A Hash represents a Ruby Hash
 type Hash struct {
-	Map map[RubyObject]RubyObject
+	hashMap map[hashKey]hashPair
+}
+
+func (h *Hash) init() {
+	if h.hashMap == nil {
+		h.hashMap = make(map[hashKey]hashPair)
+	}
+}
+
+// Set puts the object obj into the Hash
+func (h *Hash) Set(key, value RubyObject) RubyObject {
+	h.init()
+	h.hashMap[hash(key)] = hashPair{Key: key, Value: value}
+	return value
+}
+
+// Get retrieves the object for key within the hash. If not found, the boolean will be false
+func (h *Hash) Get(key RubyObject) (RubyObject, bool) {
+	v, ok := h.hashMap[hash(key)]
+	if !ok {
+		return nil, false
+	}
+	return v.Value, true
+}
+
+// Map returns a map of RubyObject to RubyObject
+func (h *Hash) Map() map[RubyObject]RubyObject {
+	hashmap := make(map[RubyObject]RubyObject)
+	for _, v := range h.hashMap {
+		hashmap[v.Key] = v.Value
+	}
+	return hashmap
 }
 
 // Type returns the ObjectType of the array
@@ -29,14 +87,22 @@ func (h *Hash) Type() Type { return HASH_OBJ }
 // surrounded by brackets
 func (h *Hash) Inspect() string {
 	elems := []string{}
-	for key, val := range h.Map {
-		elems = append(elems, fmt.Sprintf("%q => %q", key.Inspect(), val.Inspect()))
+	for _, v := range h.hashMap {
+		elems = append(elems, fmt.Sprintf("%q => %q", v.Key.Inspect(), v.Value.Inspect()))
 	}
 	return "{" + strings.Join(elems, ", ") + "}"
 }
 
 // Class returns the class of the Array
 func (h *Hash) Class() RubyClass { return hashClass }
+
+func (h *Hash) hashKey() hashKey {
+	hash := fnv.New64a()
+	for k := range h.hashMap {
+		hash.Write(k.bytes())
+	}
+	return hashKey{Type: h.Type(), Value: hash.Sum64()}
+}
 
 var hashClassMethods = map[string]RubyMethod{}
 

--- a/object/hash.go
+++ b/object/hash.go
@@ -1,0 +1,43 @@
+package object
+
+import (
+	"fmt"
+	"strings"
+)
+
+var hashClass RubyClassObject = newClass(
+	"Hash",
+	objectClass,
+	hashMethods,
+	hashClassMethods,
+	func(RubyClassObject) RubyObject { return &Hash{make(map[RubyObject]RubyObject)} },
+)
+
+func init() {
+	classes.Set("Hash", hashClass)
+}
+
+// A Hash represents a Ruby Hash
+type Hash struct {
+	Map map[RubyObject]RubyObject
+}
+
+// Type returns the ObjectType of the array
+func (h *Hash) Type() Type { return HASH_OBJ }
+
+// Inspect returns all elements within the array, divided by comma and
+// surrounded by brackets
+func (h *Hash) Inspect() string {
+	elems := []string{}
+	for key, val := range h.Map {
+		elems = append(elems, fmt.Sprintf("%q => %q", key.Inspect(), val.Inspect()))
+	}
+	return "{" + strings.Join(elems, ", ") + "}"
+}
+
+// Class returns the class of the Array
+func (h *Hash) Class() RubyClass { return hashClass }
+
+var hashClassMethods = map[string]RubyMethod{}
+
+var hashMethods = map[string]RubyMethod{}

--- a/object/hash_test.go
+++ b/object/hash_test.go
@@ -1,0 +1,208 @@
+package object
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestHashSet(t *testing.T) {
+	t.Run("Set on initialized hash", func(t *testing.T) {
+		hash := &Hash{hashMap: make(map[hashKey]hashPair)}
+
+		key := &String{Value: "foo"}
+		value := &Integer{Value: 42}
+
+		result := hash.Set(key, value)
+
+		if len(hash.hashMap) != 1 {
+			t.Logf("Expected hashMap to contain 1 item, got %d\n", len(hash.hashMap))
+			t.Fail()
+		}
+
+		var values []hashPair
+		for _, v := range hash.hashMap {
+			values = append(values, v)
+		}
+
+		if !reflect.DeepEqual(values[0].Key, key) {
+			t.Logf("Expect hashPair Key to equal\n%v\n\tgot\n%v\n", key, values[0].Key)
+			t.Fail()
+		}
+		if !reflect.DeepEqual(values[0].Value, value) {
+			t.Logf("Expect hashPair Value to equal\n%v\n\tgot\n%v\n", value, values[0].Value)
+			t.Fail()
+		}
+
+		if !reflect.DeepEqual(result, value) {
+			t.Logf("Expect returned value to equal\n%v\n\tgot\n%v\n", value, result)
+			t.Fail()
+		}
+	})
+	t.Run("Set on uninitialized hash", func(t *testing.T) {
+		var hash Hash
+
+		key := &String{Value: "foo"}
+		value := &Integer{Value: 42}
+
+		result := hash.Set(key, value)
+
+		if len(hash.hashMap) != 1 {
+			t.Logf("Expected hashMap to contain 1 item, got %d\n", len(hash.hashMap))
+			t.Fail()
+		}
+
+		var values []hashPair
+		for _, v := range hash.hashMap {
+			values = append(values, v)
+		}
+
+		if !reflect.DeepEqual(values[0].Key, key) {
+			t.Logf("Expect hashPair Key to equal\n%v\n\tgot\n%v\n", key, values[0].Key)
+			t.Fail()
+		}
+		if !reflect.DeepEqual(values[0].Value, value) {
+			t.Logf("Expect hashPair Value to equal\n%v\n\tgot\n%v\n", value, values[0].Value)
+			t.Fail()
+		}
+
+		if !reflect.DeepEqual(result, value) {
+			t.Logf("Expect returned value to equal\n%v\n\tgot\n%v\n", value, result)
+			t.Fail()
+		}
+	})
+}
+
+func TestHashGet(t *testing.T) {
+	t.Run("value found", func(t *testing.T) {
+		key := &String{Value: "foo"}
+		value := &Integer{Value: 42}
+
+		hash := &Hash{hashMap: map[hashKey]hashPair{
+			key.hashKey(): hashPair{Key: key, Value: value},
+		}}
+
+		result, ok := hash.Get(key)
+
+		if !ok {
+			t.Logf("Expected returned bool to be true, got false")
+			t.Fail()
+		}
+
+		if !reflect.DeepEqual(result, value) {
+			t.Logf("Expect returned value to equal\n%v\n\tgot\n%v\n", value, result)
+			t.Fail()
+		}
+	})
+	t.Run("value not found", func(t *testing.T) {
+		key := &String{Value: "foo"}
+
+		hash := &Hash{hashMap: map[hashKey]hashPair{}}
+
+		result, ok := hash.Get(key)
+
+		if ok {
+			t.Logf("Expected returned bool to be false, got true")
+			t.Fail()
+		}
+
+		if result != nil {
+			t.Logf("Expect returned value to be nil\n")
+			t.Fail()
+		}
+	})
+	t.Run("on uninitalized hash", func(t *testing.T) {
+		key := &String{Value: "foo"}
+
+		var hash Hash
+
+		result, ok := hash.Get(key)
+
+		if ok {
+			t.Logf("Expected returned bool to be false, got true")
+			t.Fail()
+		}
+
+		if result != nil {
+			t.Logf("Expect returned value to be nil\n")
+			t.Fail()
+		}
+	})
+}
+
+func TestHashMap(t *testing.T) {
+	t.Run("on initialized hash", func(t *testing.T) {
+		key := &String{Value: "foo"}
+		value := &Integer{Value: 42}
+
+		hash := &Hash{hashMap: map[hashKey]hashPair{
+			key.hashKey(): hashPair{Key: key, Value: value},
+		}}
+
+		var result map[RubyObject]RubyObject = hash.Map()
+
+		expected := map[string]RubyObject{
+			"foo": value,
+		}
+		actual := make(map[string]RubyObject)
+		for k, v := range result {
+			actual[k.Inspect()] = v
+		}
+
+		if !reflect.DeepEqual(expected, actual) {
+			t.Logf("Expected hash to equal\n%s\n\tgot\n%s\n", expected, actual)
+			t.Fail()
+		}
+	})
+	t.Run("on uninitialized hash", func(t *testing.T) {
+		var hash Hash
+
+		var result map[RubyObject]RubyObject = hash.Map()
+
+		expected := map[string]RubyObject{}
+		actual := make(map[string]RubyObject)
+		for k, v := range result {
+			actual[k.Inspect()] = v
+		}
+
+		if !reflect.DeepEqual(expected, actual) {
+			t.Logf("Expected hash to equal\n%s\n\tgot\n%s\n", expected, actual)
+			t.Fail()
+		}
+	})
+}
+
+func Test_hash(t *testing.T) {
+	t.Run("hashable object", func(t *testing.T) {
+		obj := &String{Value: "bar"}
+
+		hashKey := hash(obj)
+
+		if hashKey != obj.hashKey() {
+			t.Logf("Expected to get the same hashKey as from the hashKey fn, got %v", hashKey)
+			t.Fail()
+		}
+	})
+	t.Run("object which is not hashable", func(t *testing.T) {
+		obj := &basicObject{}
+
+		key := hash(obj)
+
+		expectedKeyType := obj.Type()
+
+		if key.Type != expectedKeyType {
+			t.Logf("Expected to get the same hashKey Type as the object Type, got %v", key.Type)
+			t.Fail()
+		}
+
+		obj2 := &basicObject{}
+
+		key2 := hash(obj2)
+		t.Logf("pointer obj1: %p, pointer obj2: %p\n", obj, obj2)
+
+		if key == key2 {
+			t.Logf("Expected different keys for different object instances")
+			t.Logf("obj == obj2: %t\n", obj == obj2)
+			t.Fail()
+		}
+	})
+}

--- a/object/integer.go
+++ b/object/integer.go
@@ -29,6 +29,10 @@ func (i *Integer) Type() Type { return INTEGER_OBJ }
 // Class returns integerClass
 func (i *Integer) Class() RubyClass { return integerClass }
 
+func (i *Integer) hashKey() hashKey {
+	return hashKey{Type: i.Type(), Value: uint64(i.Value)}
+}
+
 var integerClassMethods = map[string]RubyMethod{}
 
 var integerMethods = map[string]RubyMethod{

--- a/object/integer_test.go
+++ b/object/integer_test.go
@@ -5,6 +5,25 @@ import (
 	"testing"
 )
 
+func TestInteger_hashKey(t *testing.T) {
+	hello1 := &Integer{Value: 1}
+	hello2 := &Integer{Value: 1}
+	diff1 := &Integer{Value: 3}
+	diff2 := &Integer{Value: 3}
+
+	if hello1.hashKey() != hello2.hashKey() {
+		t.Errorf("strings with same content have different hash keys")
+	}
+
+	if diff1.hashKey() != diff2.hashKey() {
+		t.Errorf("strings with same content have different hash keys")
+	}
+
+	if hello1.hashKey() == diff1.hashKey() {
+		t.Errorf("strings with different content have same hash keys")
+	}
+}
+
 func TestIntegerDiv(t *testing.T) {
 	tests := []struct {
 		arguments []RubyObject

--- a/object/module.go
+++ b/object/module.go
@@ -1,5 +1,7 @@
 package object
 
+import "hash/fnv"
+
 var moduleClass RubyClassObject = &class{name: "Module", instanceMethods: NewMethodSet(moduleMethods)}
 
 func init() {
@@ -44,6 +46,11 @@ func (m *Module) Class() RubyClass {
 		return m.class
 	}
 	return moduleClass
+}
+func (m *Module) hashKey() hashKey {
+	h := fnv.New64a()
+	h.Write([]byte(m.name))
+	return hashKey{Type: m.Type(), Value: h.Sum64()}
 }
 
 func (m *Module) addMethod(name string, method RubyMethod) {

--- a/object/module_test.go
+++ b/object/module_test.go
@@ -8,6 +8,25 @@ import (
 	"testing"
 )
 
+func TestModule_hashKey(t *testing.T) {
+	hello1 := &Module{name: "Hello World"}
+	hello2 := &Module{name: "Hello World"}
+	diff1 := &Module{name: "My name is johnny"}
+	diff2 := &Module{name: "My name is johnny"}
+
+	if hello1.hashKey() != hello2.hashKey() {
+		t.Errorf("strings with same content have different hash keys")
+	}
+
+	if diff1.hashKey() != diff2.hashKey() {
+		t.Errorf("strings with same content have different hash keys")
+	}
+
+	if hello1.hashKey() == diff1.hashKey() {
+		t.Errorf("strings with different content have same hash keys")
+	}
+}
+
 func TestModuleAncestors(t *testing.T) {
 	t.Run("class extending from BasicObject", func(t *testing.T) {
 		context := &callContext{

--- a/object/object.go
+++ b/object/object.go
@@ -9,7 +9,9 @@ func init() {
 }
 
 // Object represents an Object in Ruby
-type Object struct{}
+type Object struct {
+	_ int // for uniqueness
+}
 
 // Inspect return ""
 func (o *Object) Inspect() string { return "" }

--- a/object/ruby_object.go
+++ b/object/ruby_object.go
@@ -55,6 +55,10 @@ type RubyClassObject interface {
 	RubyClass
 }
 
+type hashable interface {
+	hashKey() hashKey
+}
+
 type extendable interface {
 	addMethod(name string, method RubyMethod)
 }

--- a/object/ruby_object.go
+++ b/object/ruby_object.go
@@ -19,6 +19,7 @@ const (
 	CLASS_OBJ          Type = "CLASS"
 	CLASS_INSTANCE_OBJ Type = "CLASS"
 	ARRAY_OBJ          Type = "ARRAY"
+	HASH_OBJ           Type = "HASH"
 	INTEGER_OBJ        Type = "INTEGER"
 	STRING_OBJ         Type = "STRING"
 	SYMBOL_OBJ         Type = "SYMBOL"

--- a/object/string.go
+++ b/object/string.go
@@ -1,5 +1,7 @@
 package object
 
+import "hash/fnv"
+
 var stringClass RubyClassObject = newClass(
 	"String", objectClass, stringMethods, stringClassMethods, func(RubyClassObject) RubyObject { return &String{} },
 )
@@ -21,6 +23,13 @@ func (s *String) Type() Type { return STRING_OBJ }
 
 // Class returns stringClass
 func (s *String) Class() RubyClass { return stringClass }
+
+// hashKey returns a hash key to be used by Hashes
+func (s *String) hashKey() hashKey {
+	h := fnv.New64a()
+	h.Write([]byte(s.Value))
+	return hashKey{Type: s.Type(), Value: h.Sum64()}
+}
 
 var stringClassMethods = map[string]RubyMethod{}
 

--- a/object/string_test.go
+++ b/object/string_test.go
@@ -1,0 +1,22 @@
+package object
+
+import "testing"
+
+func TestString_hashKey(t *testing.T) {
+	hello1 := &String{Value: "Hello World"}
+	hello2 := &String{Value: "Hello World"}
+	diff1 := &String{Value: "My name is johnny"}
+	diff2 := &String{Value: "My name is johnny"}
+
+	if hello1.hashKey() != hello2.hashKey() {
+		t.Errorf("strings with same content have different hash keys")
+	}
+
+	if diff1.hashKey() != diff2.hashKey() {
+		t.Errorf("strings with same content have different hash keys")
+	}
+
+	if hello1.hashKey() == diff1.hashKey() {
+		t.Errorf("strings with different content have same hash keys")
+	}
+}

--- a/object/symbol.go
+++ b/object/symbol.go
@@ -1,5 +1,7 @@
 package object
 
+import "hash/fnv"
+
 var symbolClass RubyClassObject = newClass(
 	"Symbol", objectClass, symbolMethods, symbolClassMethods, func(RubyClassObject) RubyObject { return &Symbol{} },
 )
@@ -21,6 +23,12 @@ func (s *Symbol) Type() Type { return SYMBOL_OBJ }
 
 // Class returns symbolClass
 func (s *Symbol) Class() RubyClass { return symbolClass }
+
+func (s *Symbol) hashKey() hashKey {
+	h := fnv.New64a()
+	h.Write([]byte(s.Value))
+	return hashKey{Type: s.Type(), Value: h.Sum64()}
+}
 
 var symbolClassMethods = map[string]RubyMethod{}
 

--- a/object/symbol_test.go
+++ b/object/symbol_test.go
@@ -1,0 +1,22 @@
+package object
+
+import "testing"
+
+func TestSymbol_hashKey(t *testing.T) {
+	hello1 := &Symbol{Value: "Hello World"}
+	hello2 := &Symbol{Value: "Hello World"}
+	diff1 := &Symbol{Value: "My name is johnny"}
+	diff2 := &Symbol{Value: "My name is johnny"}
+
+	if hello1.hashKey() != hello2.hashKey() {
+		t.Errorf("strings with same content have different hash keys")
+	}
+
+	if diff1.hashKey() != diff2.hashKey() {
+		t.Errorf("strings with same content have different hash keys")
+	}
+
+	if hello1.hashKey() == diff1.hashKey() {
+		t.Errorf("strings with different content have same hash keys")
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -341,6 +341,14 @@ func (p *parser) parseAssignment(left ast.Expression) ast.Expression {
 		return p.parseVariableAssignExpression(left)
 	case *ast.Global:
 		return p.parseGlobalAssignment(left)
+	case *ast.IndexExpression:
+		assign := &ast.Assignment{
+			Token: p.curToken,
+			Left:  left,
+		}
+		p.nextToken()
+		assign.Right = p.parseExpression(precLowest)
+		return assign
 	default:
 		msg := fmt.Errorf("could not parse assignment: unexpected lefthandside token '%T'", left)
 		p.errors = append(p.errors, msg)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -11,6 +11,43 @@ import (
 	"github.com/pkg/errors"
 )
 
+func TestAssignment(t *testing.T) {
+	input := `x[:foo] = 3`
+	program, err := parseSource(input)
+	checkParserErrors(t, err)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf(
+			"program.Statements does not contain 1 statements. got=%d",
+			len(program.Statements),
+		)
+	}
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf(
+			"program.Statements[0] is not ast.ExpressionStatement. got=%T",
+			program.Statements[0],
+		)
+	}
+
+	assign, ok := stmt.Expression.(*ast.Assignment)
+	if !ok {
+		t.Fatalf(
+			"stmt.Expression is not *ast.Assignment. got=%T",
+			stmt.Expression,
+		)
+	}
+
+	if _, ok = assign.Left.(*ast.IndexExpression); !ok {
+		t.Fatalf(
+			"assign.Left is not *ast.IndexExpression. got=%T",
+			stmt.Expression,
+		)
+	}
+
+	testIntegerLiteral(t, assign.Right, 3)
+}
+
 func TestVariableExpression(t *testing.T) {
 	t.Run("valid variable expressions", func(t *testing.T) {
 		tests := []struct {
@@ -44,6 +81,12 @@ func TestVariableExpression(t *testing.T) {
 			}
 
 			variable, ok := stmt.Expression.(*ast.VariableAssignment)
+			if !ok {
+				t.Fatalf(
+					"stmt.Expression is not *ast.VariableAssignment. got=%T",
+					stmt.Expression,
+				)
+			}
 
 			if !testIdentifier(t, variable.Name, tt.expectedIdentifier) {
 				return
@@ -111,6 +154,12 @@ func TestGlobalAssignment(t *testing.T) {
 	}
 
 	variable, ok := stmt.Expression.(*ast.GlobalAssignment)
+	if !ok {
+		t.Fatalf(
+			"stmt.Expression is not *ast.GlobalAssignment. got=%T",
+			stmt.Expression,
+		)
+	}
 
 	expectedGlobal := "$foo"
 

--- a/token/token.go
+++ b/token/token.go
@@ -37,6 +37,8 @@ const (
 	NOTEQ // !=
 	operator_end
 
+	HASHROCKET // =>
+
 	// Delimiters
 
 	NEWLINE // \n
@@ -110,7 +112,8 @@ var tokens = [...]string{
 	RBRACKET: "]",
 	PIPE:     "|",
 
-	SCOPE: "::",
+	SCOPE:      "::",
+	HASHROCKET: "=>",
 
 	DEF:    "def",
 	SELF:   "self",


### PR DESCRIPTION
Not yet there: hashes with a different syntax, as in `{foo: 'bar'}`, or allowing hashes as last argument of a method call to omit braces.
This branch is based on / includes the Parser refactoring [#47](https://github.com/goruby/goruby/pull/47) and String symbols [#49](https://github.com/goruby/goruby/pull/49). These two have to be merged before I guess.