### PR TITLE
Update format-string for test-case

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -23,7 +23,7 @@ func TestMain(m *testing.M) {
 	var ok bool
 	parseMode, ok = parseModes[*mode]
 	if !ok {
-		fmt.Printf("Unknown parse mode %q\n", mode)
+		fmt.Printf("Unknown parse mode %s\n", *mode)
 		os.Exit(1)
 	}
 	os.Exit(m.Run())


### PR DESCRIPTION
Running the test-cases failed for me, from the current `master`:

       frodo ~/go/src/github.com/goruby/goruby $ go test ./...
       ?   	github.com/goruby/goruby	[no test files]
       ok  	github.com/goruby/goruby/ast	(cached)
       ?   	github.com/goruby/goruby/cmd/girb	[no test files]
       ok  	github.com/goruby/goruby/evaluator	(cached)
       ok  	github.com/goruby/goruby/interpreter	(cached)
       ok  	github.com/goruby/goruby/lexer	(cached)
       # github.com/goruby/goruby/parser
       parser/parser_test.go:26: Printf format %q has arg mode of wrong type *string
       ok  	github.com/goruby/goruby/object	(cached)
       FAIL	github.com/goruby/goruby/parser [build failed]
       ?   	github.com/goruby/goruby/repl	[no test files]
       ?   	github.com/goruby/goruby/token	[no test files]

This pull-request updates the format-string and argument, so that the tests pass:

      frodo ~/go/src/github.com/goruby/goruby/parser $ go test .
      ok  	github.com/goruby/goruby/parser	(cached)
      frodo ~/go/src/github.com/goruby/goruby/parser $ 

